### PR TITLE
Experimental Brushes outside the editor

### DIFF
--- a/Assets/Scripts/UserConfig.cs
+++ b/Assets/Scripts/UserConfig.cs
@@ -39,7 +39,7 @@ public class UserConfig {
     bool? m_ShowDangerousBrushes;
     public bool ShowDangerousBrushes {
       get {
-#if UNITY_EDITOR
+#if EXPERIMENTAL_ENABLED
         return m_ShowDangerousBrushes ?? true;
 #else
         return m_ShowDangerousBrushes ?? false;


### PR DESCRIPTION
Thanks to pld, we found that the experimental brushes setting being changed by UserConfig.cs and dependent on being in the Unity Editor. Changed it to be dependent on the experimental setting changed in Tilt>Build>Experimental setting. 