### PR TITLE
Add nullcheck when enabling profiling

### DIFF
--- a/Assets/Scripts/VrSdk.cs
+++ b/Assets/Scripts/VrSdk.cs
@@ -951,7 +951,11 @@ public class VrSdk : MonoBehaviour {
   /// So that they can be restored later with RestorePoseTracking.
   public void DisablePoseTracking() {
     m_TrackingBackupXf = TrTransform.FromTransform(GetVrCamera().transform);
-    m_OldOnPoseApplied = NewControllerPosesApplied.GetInvocationList().Cast<Action>().ToArray();
+    if (NewControllerPosesApplied == null) {
+      m_OldOnPoseApplied = Array.Empty<Action>();
+    } else {
+      m_OldOnPoseApplied = NewControllerPosesApplied.GetInvocationList().Cast<Action>().ToArray();
+    }
     NewControllerPosesApplied = null;
   }
 


### PR DESCRIPTION
Fixes crash on: https://github.com/icosa-gallery/open-brush/issues/7.
Head tracking is still disabled when profiling. ~~It looks intentional, but I'm not sure.~~ It is intentional