### PR TITLE
Enable ExperimentalBrushes in Editor too

### DIFF
--- a/Assets/Scripts/UserConfig.cs
+++ b/Assets/Scripts/UserConfig.cs
@@ -39,7 +39,7 @@ public class UserConfig {
     bool? m_ShowDangerousBrushes;
     public bool ShowDangerousBrushes {
       get {
-#if EXPERIMENTAL_ENABLED
+#if EXPERIMENTAL_ENABLED || UNITY_EDITOR
         return m_ShowDangerousBrushes ?? true;
 #else
         return m_ShowDangerousBrushes ?? false;


### PR DESCRIPTION
I believe with the current build, experimental brushes may not show in the editor due to settings being overwritten by UserConfig, I should have tested more thoughly before merging my last PR, apologies. 

Opening this small PR as I noticed people forking us, I did not want them to struggle getting experimental brushes. 