### PR TITLE
Fixes for Quest version

### DIFF
--- a/Assets/Editor/BuildTiltBrush.cs
+++ b/Assets/Editor/BuildTiltBrush.cs
@@ -733,7 +733,7 @@ static class BuildTiltBrush {
       m_company = PlayerSettings.companyName;
       if (m_isAndroid) {
         PlayerSettings.SetApplicationIdentifier(BuildTargetGroup.Android,
-                                                App.kGuiBuildAndroidExecutableName);
+                                                App.kGuiBuildAndroidApplicationIdentifier);
       }
       PlayerSettings.productName = App.kAppDisplayName;
       PlayerSettings.companyName = App.kDisplayVendorName;

--- a/Assets/Scripts/App.cs
+++ b/Assets/Scripts/App.cs
@@ -69,9 +69,10 @@ public class App : MonoBehaviour {
   public const string kGuiBuildWindowsExecutableName = kGuiBuildExecutableName + ".exe";
   // OSX Executable
   public const string kGuiBuildOSXExecutableName = kGuiBuildExecutableName + ".app";
+  // Android Application Identifier
+  public const string kGuiBuildAndroidApplicationIdentifier = "com." + kVendorName + "." + kGuiBuildExecutableName;
   // Android Executable
-  public const string kGuiBuildAndroidExecutableName =
-      "com." + kVendorName + "." + kGuiBuildExecutableName + ".apk";
+  public const string kGuiBuildAndroidExecutableName = kGuiBuildAndroidApplicationIdentifier + ".apk";
 
   public const string kPlayerPrefHasPlayedBefore = "Has played before";
   public const string kReferenceImagesSeeded = "Reference Images seeded";

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -179,7 +179,7 @@ PlayerSettings:
     iPhone: 0
   AndroidBundleVersionCode: 1
   AndroidMinSdkVersion: 24
-  AndroidTargetSdkVersion: 29
+  AndroidTargetSdkVersion: 28
   AndroidPreferredInstallLocation: 0
   aotOptions: 
   stripEngineCode: 1

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -177,7 +177,7 @@ PlayerSettings:
     tvOS: com.yourcompany.yourproduct
   buildNumber:
     iPhone: 0
-  AndroidBundleVersionCode: 0
+  AndroidBundleVersionCode: 1
   AndroidMinSdkVersion: 24
   AndroidTargetSdkVersion: 29
   AndroidPreferredInstallLocation: 0
@@ -450,7 +450,6 @@ PlayerSettings:
     m_Enabled: 1
     m_Devices:
     - OpenVR
-    - Oculus
   - m_BuildTarget: Tizen
     m_Enabled: 0
     m_Devices: []


### PR DESCRIPTION
Some small fixes for the Quest version:

Gradle requires a android build number higher than 0: moved it to 1

Changed the default bundle name to not include `.apk`, while preserving it on the output file.