### PR TITLE
Fixes for developing on OS X

### DIFF
--- a/Assets/Editor/BuildTiltBrush.cs
+++ b/Assets/Editor/BuildTiltBrush.cs
@@ -1354,10 +1354,18 @@ static class BuildTiltBrush {
   }
 
   private static void SyncDirectoryTo(string source, string destination, bool subdirs = true) {
+#if UNITY_EDITOR_WIN
     string args = string.Format("\"{0}\" \"{1}\" {2} /PURGE",
                                 source, destination, subdirs ? "/E" : "");
+    string copyexe = "robocopy.exe";
+#else
+    string args = string.Format("\"{0}/\" \"{1}/\" {2} --delete",
+                                source, destination, subdirs ? "-a": "-d");
+    string copyexe = "rsync";
+#endif
+
     var process = new System.Diagnostics.Process();
-    process.StartInfo = new System.Diagnostics.ProcessStartInfo("robocopy.exe", args);
+    process.StartInfo = new System.Diagnostics.ProcessStartInfo(copyexe, args);
     process.StartInfo.UseShellExecute = false;
     process.StartInfo.CreateNoWindow = true;
     process.Start();

--- a/Assets/Editor/BuildTiltBrush.cs
+++ b/Assets/Editor/BuildTiltBrush.cs
@@ -1405,6 +1405,9 @@ static class BuildTiltBrush {
     StringBuilder args = new StringBuilder();
     string logFile = Path.Combine(rootCopyDir.FullName, "BackgroundBuild.log");
     FileUtil.DeleteFileOrDirectory(logFile);
+#if UNITY_EDITOR_OSX
+    args.AppendFormat("--args ");
+#endif
     args.AppendFormat("-logFile {0} ", logFile);
     if (!interactive) { args.Append("-batchmode "); }
     args.AppendFormat("-projectpath {0} ", rootCopyDir.FullName);
@@ -1424,8 +1427,13 @@ static class BuildTiltBrush {
     if (!interactive) { args.Append("-quit "); }
 
     var process = new System.Diagnostics.Process();
-    process.StartInfo = new System.Diagnostics.ProcessStartInfo(
-        EditorApplication.applicationPath, args.ToString());
+    StringBuilder unityPath = new StringBuilder();
+    unityPath.AppendFormat(EditorApplication.applicationPath);
+#if UNITY_EDITOR_OSX
+    // We want to run the inner Unity executable, not the GUI wrapper
+    unityPath.AppendFormat("/Contents/MacOS/Unity");
+#endif
+    process.StartInfo = new System.Diagnostics.ProcessStartInfo(unityPath.ToString(), args.ToString());
     DetectBackgroundProcessExit(process);
     process.Start();
     s_BackgroundBuildProcessId = process.Id;

--- a/Assets/Editor/BuildWindow.cs
+++ b/Assets/Editor/BuildWindow.cs
@@ -524,8 +524,13 @@ namespace TiltBrush {
 
     public static string[] RunAdb(params string[] arguments) {
       var process = new System.Diagnostics.Process();
+#if UNITY_EDITOR_WIN
       process.StartInfo =
           new System.Diagnostics.ProcessStartInfo("adb.exe", String.Join(" ", arguments));
+#else
+      process.StartInfo =
+          new System.Diagnostics.ProcessStartInfo("adb", String.Join(" ", arguments));
+#endif
       process.StartInfo.UseShellExecute = false;
       process.StartInfo.CreateNoWindow = true;
       process.StartInfo.RedirectStandardOutput = true;


### PR DESCRIPTION
Fix build window, adb, and background builds (should also help on Linux, by using rsync instead of robocopy, but I didn't test anything on Linux.