### PR TITLE
update FBX Support Guide

### DIFF
--- a/Support/fbx/README.md
+++ b/Support/fbx/README.md
@@ -15,5 +15,5 @@ functions implemented in C for speed.
 1. Add the package to your Tilt Brush project. The quickest way to do this
    is to copy or link the resulting directory `build/install/com.autodesk.fbx`
    into the `Packages` directory of your Tilt Brush repository.
-1. Add `FBX_SUPPORTED` to Project Settings -> Player -> Scripting Define
+1. Add `FBX_SUPPORTED` and `FBXSDK_RUNTIME` to Project Settings -> Player -> Scripting Define
    Symbols.


### PR DESCRIPTION
actually try this, find that you also need to add `FBXSDK_RUNTIME`.
If you don't add it, you will get the following error message when building

```
error CS0246: The type or namespace name 'Autodesk' could not be found (are you missing a using directive or an assembly reference?)
````

sorry for your inconvenience.
This is a re-creation of Pull Requests #9 due to a change in the configuration of my repository.

