### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+
+# https://EditorConfig.org
+
+root = true
+
+[*.{cs,py,json,cfg}]
+indent_style = space
+indent_size = 2
+


### PR DESCRIPTION
- See https://editorconfig.org/
- .cs and .py files use 2 space indents.