### PR TITLE
Fix undefined reference to InitUsd.Initialize() on Quest 2

### DIFF
--- a/Assets/Scripts/App.cs
+++ b/Assets/Scripts/App.cs
@@ -607,8 +607,10 @@ public class App : MonoBehaviour {
       m_RoomRadius = Mathf.Min(Mathf.Abs(extents.x), Mathf.Abs(extents.z));
     }
 
+#if USD_SUPPORTED
     // Load the Usd Plugins
     InitUsd.Initialize();
+#endif
 
     foreach (string s in Config.m_SketchFiles) {
       // Assume all relative paths are relative to the Sketches directory.


### PR DESCRIPTION
Followup to #33 