### PR TITLE
Enable desktop GIF modes

### DIFF
--- a/Assets/PlatformConfigPC.asset
+++ b/Assets/PlatformConfigPC.asset
@@ -31,7 +31,7 @@ MonoBehaviour:
   EnableExportUsd: 1
   EnableExportMemoryOptimization: 1
   EnableMulticamPreview: 1
-  EnabledMulticamStyles: 0000000003000000
+  EnabledMulticamStyles: 00000000010000000200000003000000
   MaxSnapshotDimension: 16000
   FrameRateToPreviewRenderGap:
     serializedVersion: 2


### PR DESCRIPTION
Desktop GIF modes were left out of #15 to prevent a merge conflict, this enables them