### PR TITLE
[DO NOT MERGE] Get activation file for use in Unity CI builds

### DIFF
--- a/.github/workflows/get_license.yml
+++ b/.github/workflows/get_license.yml
@@ -1,0 +1,22 @@
+name: Acquire activation file
+on:
+  push:
+    branches:
+      - get_license
+jobs:
+  activation:
+    name: Request manual activation file 🔑
+    runs-on: ubuntu-latest
+    steps:
+      # Request manual activation file
+      - name: Request manual activation file
+        id: getManualLicenseFile
+        uses: game-ci/unity-request-activation-file@v2.0-alpha-1
+        with:
+          unityVersion: 2019.4.18f1
+      # Upload artifact (Unity_v20XX.X.XXXX.alf)
+      - name: Expose as artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ steps.getManualLicenseFile.outputs.filePath }}
+          path: ${{ steps.getManualLicenseFile.outputs.filePath }}


### PR DESCRIPTION
Once this file has been downloaded (from the artifacts) and then uploaded to license.unity3d.com, this PR can be closed and the branch can be deleted.