### PR TITLE
Sign all builds that are built from pushes to main

### DIFF
--- a/.github/workflows/unity.yml
+++ b/.github/workflows/unity.yml
@@ -127,6 +127,10 @@ jobs:
           else
             echo "No value for git describe found!"
           fi
+      - name: Enable the use of a custom keystore
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          sed -e 's/androidUseCustomKeystore.*$/androidUseCustomKeystore: 1/' -i ProjectSettings/ProjectSettings.asset
 
       - name: Build project
         uses: game-ci/unity-builder@v2.0-alpha-6
@@ -136,6 +140,11 @@ jobs:
           targetPlatform: ${{ matrix.targetPlatform }}
           customParameters: -btb-target ${{ matrix.targetPlatform }} -btb-display ${{ matrix.vrsdk }} -btb-out /github/workspace/build/${{ matrix.targetPlatform }}-${{ matrix.vrsdk }}/${{ env.filename }} -btb-github ${{ env.stamp }} ${{ matrix.extraoptions }}
           buildMethod: BuildTiltBrush.CommandLine
+          androidKeystoreName: openbrush.keystore
+          androidKeystoreBase64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          androidKeystorePass: ${{ secrets.ANDROID_KEYSTORE_PASS }}
+          androidKeyaliasName: ${{ secrets.ANDROID_KEYALIAS_NAME }}
+          androidKeyaliasPass: ${{ secrets.ANDROID_KEYALIAS_PASS }}
 
       - name: Set executable permissions (for OSX)
         if: matrix.targetPlatform == 'StandaloneOSX'

--- a/Assets/Editor/BuildTiltBrush.cs
+++ b/Assets/Editor/BuildTiltBrush.cs
@@ -610,6 +610,9 @@ static class BuildTiltBrush {
     };
     string keystoreName = null;
     string keyaliasName = null;
+    string keystorePass = Environment.GetEnvironmentVariable("BTB_KEYSTORE_PASS");
+    string keyaliasPass = Environment.GetEnvironmentVariable("BTB_KEYALIAS_PASS");
+
 
 #if OCULUS_SUPPORTED
     // Call these once to create the files. Normally (i.e., in a GUI build), they're created with
@@ -670,13 +673,16 @@ static class BuildTiltBrush {
           // TODO: do we want to do anything with this? Can we use it instead of the version string
           // set externally?
           i++;
-        } else if (args[i] == "-androidVersionCode" ||
-            args[i] == "-androidKeystoreName" ||
-            args[i] == "-androidKeystorePass" ||
-            args[i] == "-androidKeyaliasName" ||
-            args[i] == "-androidKeyaliasPass") {
-          // TODO: do we want to do anything with these?
+        } else if (args[i] == "-androidVersionCode") {
           i++;
+        } else if (args[i] == "-androidKeystoreName") {
+          keystoreName = args[++i];
+        } else if (args[i] == "-androidKeystorePass") {
+          keystorePass = args[++i];
+        } else if (args[i] == "-androidKeyaliasName") {
+          keyaliasName = args[++i];
+        } else if (args[i] == "-androidKeyaliasPass") {
+          keyaliasPass = args[++i];
         } else if (args[i] == "-setDefaultPlatformTextureFormat") {
           i++;
         } else {
@@ -698,8 +704,8 @@ static class BuildTiltBrush {
     }
     tiltOptions.Target = target.Value;
     using (var unused = new TempSetCommandLineOnlyPlayerSettings(
-               keystoreName, Environment.GetEnvironmentVariable("BTB_KEYSTORE_PASS"),
-               keyaliasName, Environment.GetEnvironmentVariable("BTB_KEYALIAS_PASS"))) {
+               keystoreName, keystorePass,
+               keyaliasName, keyaliasPass)) {
       DoBuild(tiltOptions);
     }
   }


### PR DESCRIPTION
This requires the addition of 4 secrets:

ANDROID_KEYSTORE_BASE64 -- the output of `base64 -i foo.keystore`
ANDROID_KEYSTORE_PASS -- the password for the keystore
ANDROID_KEYALIAS_NAME -- the name of the alias
ANDROID_KEYALIAS_PASS -- should match KEYSTORE_PASS in our case

Because it uses Github secrets, it won't run on a fork, so we won't do
this for PRs. But anything coming from the main tree can use this.

We do still keep the github name in the package name, to differentiate
between a formal release and an unreleased candidate.