### PR TITLE
Only run CI builds on icosa-gallery/open-brush

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build:
     name: ${{ matrix.name }}
+    if: github.repository == 'icosa-gallery/open-brush'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
This means that pushes to a fork's main will not trigger a signed build
(which will fail) and PRs *to* forks will not run builds. PRs *from*
forks are unaffected.