### PR TITLE
Build all commits with [CI BUILD] somewhere in the commit message

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - main
+      - "*"
     tags:
       - "v*"
 
@@ -15,6 +15,16 @@ env:
 
 jobs:
   configuration:
+    if: |
+      (github.event_name == 'pull_request') ||
+      (
+        github.event_name == 'push' &&
+        (
+        github.ref == 'refs/heads/main' ||
+        contains(github.ref, 'refs/tags/v') ||
+        contains(github.event.head_commit.message, '[CI BUILD]')
+        )
+      )
     name: Configure Build Parameters
     runs-on: ubuntu-latest
     outputs:
@@ -285,7 +295,9 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' &&
-      github.repository == 'icosa-gallery/open-brush'
+      github.repository == 'icosa-gallery/open-brush' &&
+      (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/v'))
+
     strategy:
       fail-fast: false
 


### PR DESCRIPTION
This will allow users who have enabled Github Actions on their fork to create builds using CI without needing a local environment and without creating a PR just to build.

The current behavior of builds on PR submission + merge to main + tag with `vX.Y` is unaffected. 