### PR TITLE
Fix/monoscopic

### DIFF
--- a/Assets/Prefabs/VrSystems/VrControllers/NonVrControls.prefab
+++ b/Assets/Prefabs/VrSystems/VrControllers/NonVrControls.prefab
@@ -111,7 +111,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1c94cee59aeb87c4b8738f004b002294, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_ControllerName: 0
+  m_ControllerName: 1
   m_ControllerGeometryPrefab: {fileID: 114000011295956858, guid: 5dc4999f1746f8a4296af50951bb394c,
     type: 3}
   m_GeometryOffset: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/App.cs
+++ b/Assets/Scripts/App.cs
@@ -465,10 +465,6 @@ public class App : MonoBehaviour {
         m_IntroSketchRenderers[i].material.SetFloat("_GreyScale", 0);
       }
     }
-    else
-    {
-      Debug.Log("No intro sketch prefab");
-    }
   }
 
   void DestroyIntroSketch() {

--- a/Assets/Scripts/App.cs
+++ b/Assets/Scripts/App.cs
@@ -456,11 +456,18 @@ public class App : MonoBehaviour {
   }
 
   void CreateIntroSketch() {
-    m_IntroSketch = Instantiate(PlatformConfig.IntroSketchPrefab);
-    m_IntroSketchRenderers = m_IntroSketch.GetComponentsInChildren<Renderer>();
-    for (int i = 0; i < m_IntroSketchRenderers.Length; ++i) {
-      m_IntroSketchRenderers[i].material.SetFloat("_IntroDissolve", 1);
-      m_IntroSketchRenderers[i].material.SetFloat("_GreyScale", 0);
+    // Load intro if not already cached.
+    if (m_IntroSketch == null && PlatformConfig.IntroSketchPrefab != null) {
+      m_IntroSketch = Instantiate(PlatformConfig.IntroSketchPrefab);
+      m_IntroSketchRenderers = m_IntroSketch.GetComponentsInChildren<Renderer>();
+      for (int i = 0; i < m_IntroSketchRenderers.Length; ++i) {
+        m_IntroSketchRenderers[i].material.SetFloat("_IntroDissolve", 1);
+        m_IntroSketchRenderers[i].material.SetFloat("_GreyScale", 0);
+      }
+    }
+    else
+    {
+      Debug.Log("No intro sketch prefab");
     }
   }
 

--- a/Assets/Scripts/GUI/SketchSurfacePanel.cs
+++ b/Assets/Scripts/GUI/SketchSurfacePanel.cs
@@ -323,9 +323,10 @@ public class SketchSurfacePanel : BasePanel {
     ActiveTool.UpdateTool();
     if (ActiveTool.ExitRequested()) {
       // Requesting a tool exit puts us back at our default tool.
+      ActiveTool.EnableTool(false); // clean up current tool
       EnableDefaultTool();
       ActiveTool.EatInput();
-
+      
       // If we're currently loading, hide our default tool.
       if (App.Instance.IsLoading()) {
         PointerManager.m_Instance.RequestPointerRendering(false);


### PR DESCRIPTION
In monoscopic mode, if you delete something you latch into that mode and can't escape. This fixes the modal exit.

Also fixes loading issue with scene caching.

**Note: you must have experimental build for monoscopic to work.**

Tested on Win10.