### PR TITLE
Fix Poly panel fix

### DIFF
--- a/Assets/Scripts/GUI/PolyPanel.cs
+++ b/Assets/Scripts/GUI/PolyPanel.cs
@@ -65,7 +65,8 @@ public class PolyPanel : ModalPanel {
     m_NoLikesMessage.SetActive(false);
     m_NotLoggedInMessage.SetActive(false);
     m_OutOfDateMessage.SetActive(false);
-    m_NotSupportedMessage.SetActive(false);
+    if(m_NotSupportedMessage)
+      m_NotSupportedMessage.SetActive(false);
     m_NoPolyConnectionMessage.SetActive(false);
   }
 


### PR DESCRIPTION
Checks for the panel existing before disabling. d'oh.

Sidenote, why doesn't `m_NotSupportedMessage?.SetActive(false);` work here?