### PR TITLE
Feature/android debug

### DIFF
--- a/Assets/Editor/BuildWindow.cs
+++ b/Assets/Editor/BuildWindow.cs
@@ -471,6 +471,8 @@ namespace TiltBrush {
 
     private void OnBuildSettingsChanged()
     {
+      // Only set this if supporting SDK that needs Android (and is installed!).
+#if OCULUS_SUPPORTED
 #if UNITY_EDITOR_WIN
       string adbExe = "adb.exe";
 #else
@@ -480,6 +482,7 @@ namespace TiltBrush {
       m_adbPath = BuildTiltBrush.GuiSelectedBuildTarget == BuildTarget.Android
         ? Path.Combine(UnityEditor.Android.AndroidExternalToolsSettings.sdkRootPath, "platform-tools", adbExe)
         : null;
+#endif
 
       m_currentBuildPath = BuildTiltBrush.GetAppPathForGuiBuild();
       if (File.Exists(m_currentBuildPath)) {


### PR DESCRIPTION
Attempts to make Android build more friendly.

- Add adb path to Build Window. Can't build/upload/run without it.
- Read adb path from Unity config so we're using the same one as the SDK used to build the app.
