### PR TITLE
Name builds based on the source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,8 @@ jobs:
       stamp: ${{ steps.version.outputs.stamp }}
       prerelease: ${{ steps.version.outputs.prerelease }}
       changelog: ${{ steps.changelog.outputs.changelog }}
-      btbgithub: ${{ steps.github.outputs.btbgithub }}
       basename: ${{ steps.github.outputs.basename }}
+      description: ${{ steps.github.outputs.description}}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -81,18 +81,31 @@ jobs:
           CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
           CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
           echo "::set-output name=changelog::$CHANGELOG"
-      - name: Set github suffix if relevant
+      - name: Set custom app name and package name, if relevant
         id: github
         env:
           PRERELEASE: ${{ steps.version.outputs.prerelease }}
         run: |
-          if [ "$PRERELEASE" == "true" ]
+          # For a PR action (i.e., syncronize / open), the value of github.ref will be refs/pull/1234/merge
+          # For a push action, it will be either refs/heads/foo_branch_name OR refs/tags/v1234.
+          # We want to use the base name for pushes of tags or to main, the PR number for PRs, and the branch name for named branches.
+          if [[ "$PRERELEASE" == "false" || ${{ github.ref }} == refs/heads/main ]]
           then
-            echo "::set-output name=btbgithub::-btb-github"
-            echo "::set-output name=basename::OpenBrush-github"
-          else
-            echo "::set-output name=btbgithub::"
             echo "::set-output name=basename::OpenBrush"
+            echo "::set-output name=description::"
+          else
+            if [[ ${{ github.ref }} == refs/pull/* ]]
+            then
+              DESCRIPTION="PR#$(echo ${{ github.ref }} | sed -e 's#refs/pull/##' -e 's#/merge##')"
+            elif [[ ${{ github.ref }} == refs/heads/* ]]
+            then
+              DESCRIPTION="$(echo ${{ github.ref }} | sed -e 's#refs/heads/##')"
+            else
+              DESCRIPTION="Unknown"
+            fi
+            echo "::set-output name=description::-btb-description ${DESCRIPTION}"
+            IDENTIFIER=$(echo ${DESCRIPTION} | sed -e 's/[#_-]//g')
+            echo "::set-output name=basename::OpenBrush-${IDENTIFIER}"
           fi
   build:
     name: ${{ matrix.name }}
@@ -242,7 +255,7 @@ jobs:
         env:
           BASENAME: ${{ needs.configuration.outputs.basename}}
         run:
-          echo "filename=com.Icosa.$(echo $BASENAME | sed -e 's/-//g').apk" >> $GITHUB_ENV
+          echo "filename=com.Icosa.$BASENAME.apk" >> $GITHUB_ENV
 
       - name: Set build stamp
         if: ${{ needs.configuration.outputs.stamp }}
@@ -293,7 +306,7 @@ jobs:
           allowDirtyBuild: true  # Because of the OVR Update, the build tree might be dirty
           unityVersion: ${{ env.UNITY_VERSION }}
           targetPlatform: ${{ matrix.targetPlatform }}
-          customParameters: -btb-target ${{ matrix.targetPlatform }} -btb-display ${{ matrix.vrsdk }} -btb-out /github/workspace/build/${{ matrix.targetPlatform }}-${{ matrix.vrsdk }}/${{ env.filename }} ${{ needs.configuration.outputs.btbgithub }} ${{ env.stamp }} ${{ matrix.extraoptions }}
+          customParameters: -btb-target ${{ matrix.targetPlatform }} -btb-display ${{ matrix.vrsdk }} -btb-out /github/workspace/build/${{ matrix.targetPlatform }}-${{ matrix.vrsdk }}/${{ env.filename }} ${{ needs.configuration.outputs.description}} ${{ env.stamp }} ${{ matrix.extraoptions }}
           versioning: Custom
           version: ${{ needs.configuration.outputs.version }}
           buildMethod: BuildTiltBrush.CommandLine
@@ -400,9 +413,9 @@ jobs:
           zip -r OpenBrush_Desktop_Experimental_$VERSION.zip OpenBrush_Desktop_Experimental_$VERSION/
           zip -r OpenBrush_Rift_$VERSION.zip OpenBrush_Rift_$VERSION/
           zip -r OpenBrush_Rift_Experimental_$VERSION.zip OpenBrush_Rift_Experimental_$VERSION/
-          chmod a+x OpenBrush_Linux_$VERSION/OpenBrush || chmod a+x OpenBrush_Linux_$VERSION/OpenBrush-github
+          chmod a+x OpenBrush_Linux_$VERSION/OpenBrush*
           tar cvfz OpenBrush_Linux_$VERSION.tgz OpenBrush_Linux_$VERSION/
-          chmod a+x OpenBrush_Linux_Experimental_$VERSION/OpenBrush || chmod a+x OpenBrush_Linux_Experimental_$VERSION/OpenBrush-github
+          chmod a+x OpenBrush_Linux_Experimental_$VERSION/OpenBrush*
           tar cvfz OpenBrush_Linux_Experimental_$VERSION.tgz OpenBrush_Linux_Experimental_$VERSION/
           rm -rf OpenBrush_Desktop_$VERSION
           rm -rf OpenBrush_Desktop_Experimental_$VERSION

--- a/Assets/Editor/BuildTiltBrush.cs
+++ b/Assets/Editor/BuildTiltBrush.cs
@@ -47,7 +47,7 @@ static class BuildTiltBrush
         public string Location;
         public string Stamp;
         public BuildOptions UnityOptions;
-        public bool Github;
+        public string Description;
     }
 
     [Serializable()]
@@ -304,7 +304,7 @@ static class BuildTiltBrush
             UnityOptions = GuiDevelopment
                 ? (BuildOptions.AllowDebugging | BuildOptions.Development)
                 : BuildOptions.None,
-            Github = false,
+            Description = "(unity editor)",
         };
     }
 
@@ -742,9 +742,9 @@ static class BuildTiltBrush
                 {
                     tiltOptions.Experimental = true;
                 }
-                else if (args[i] == "-btb-github")
+                else if (args[i] == "-btb-description")
                 {
-                    tiltOptions.Github = true;
+                    tiltOptions.Description = args[++i];
                 }
                 else if (args[i] == "-btb-il2cpp")
                 {
@@ -937,7 +937,7 @@ static class BuildTiltBrush
         private string m_name;
         private string m_company;
         private bool m_isAndroid;
-        public TempSetAppNames(bool isAndroid, bool isGithub)
+        public TempSetAppNames(bool isAndroid, string Description)
         {
             m_isAndroid = isAndroid;
             m_identifier = PlayerSettings.GetApplicationIdentifier(BuildTargetGroup.Android);
@@ -945,10 +945,10 @@ static class BuildTiltBrush
             m_company = PlayerSettings.companyName;
             string new_name = App.kAppDisplayName;
             string new_identifier = App.kGuiBuildAndroidApplicationIdentifier;
-            if (isGithub)
+            if (!String.IsNullOrEmpty(Description))
             {
-                new_name += " (Github)";
-                new_identifier += "-github";
+                new_name += " (" + Description + ")";
+                new_identifier += Description.Replace("_", "").Replace("#", "").Replace("-", "");
             }
             if (m_isAndroid)
             {
@@ -1242,7 +1242,7 @@ static class BuildTiltBrush
         using (var unused4 = new TempHookUpSingletons())
         using (var unused5 = new TempSetScriptingBackend(target, tiltOptions.Il2Cpp))
         using (var unused6 = new TempSetBundleVersion(App.Config.m_VersionNumber, stamp))
-        using (var unused10 = new TempSetAppNames(target == BuildTarget.Android, tiltOptions.Github))
+        using (var unused10 = new TempSetAppNames(target == BuildTarget.Android, tiltOptions.Description))
         using (var unused7 = new RestoreVrSdks())
         using (var unused9 = new RestoreFileContents(
             Path.Combine(Path.GetDirectoryName(Application.dataPath),


### PR DESCRIPTION
In order to make it easier to run multiple versions, instead of a fixed
"-github" name (and package name of com.icosa.openbrushgithub), this
commit changes the logic for CI builds.

* Builds from PRs are named PR#xx (PRxx in the package name)
* Builds from branches (triggered with a [CI BUILD] tag) are named based on the branch
name. Special characters of /[#_-]/ are removed from the package name
* All commits on main have the same name, whether they're pre-release
builds or formal release builds. This means that the pre-release builds
will NOT have a unique name, but this will allow us to upload them to a
"beta" release channel