### PR TITLE
Update README & BuildTiltBrush.cs for beginners

### DIFF
--- a/Assets/Editor/BuildTiltBrush.cs
+++ b/Assets/Editor/BuildTiltBrush.cs
@@ -1218,6 +1218,7 @@ static class BuildTiltBrush
         string stamp = tiltOptions.Stamp;
         SdkMode vrSdk = tiltOptions.VrSdk;
         BuildOptions options = tiltOptions.UnityOptions;
+        // Add your new scenes in this List for your app for Oculus Quest 
         string[] scenes = { "Assets/Scenes/Loading.unity", "Assets/Scenes/Main.unity" };
         Note("BuildTiltBrush: Start target:{0} mode:{1} exp:{2} profile:{3} options:{4}",
             target, vrSdk, tiltOptions.Experimental, tiltOptions.AutoProfile,

--- a/Assets/Editor/BuildTiltBrush.cs
+++ b/Assets/Editor/BuildTiltBrush.cs
@@ -1218,7 +1218,9 @@ static class BuildTiltBrush
         string stamp = tiltOptions.Stamp;
         SdkMode vrSdk = tiltOptions.VrSdk;
         BuildOptions options = tiltOptions.UnityOptions;
-        // Add your new scenes in this List for your app for Oculus Quest 
+        // Add your new scenes in this List for your app.
+        // During the build process the Scene List in the Build Settings is ignored.
+        // Only the following scenes are included in the build.
         string[] scenes = { "Assets/Scenes/Loading.unity", "Assets/Scenes/Main.unity" };
         Note("BuildTiltBrush: Start target:{0} mode:{1} exp:{2} profile:{3} options:{4}",
             target, vrSdk, tiltOptions.Experimental, tiltOptions.AutoProfile,

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ Follow these steps to build your app for Oculus Quest:
     `../Builds/OculusMobile_Release_OpenBrush_FromGui/`.
 1.  Run `adb install com.Icosa.OpenBrush.apk`.
 
+**Note:** Add your new scene files' names in List '`scene`' on 1221st line in `../Assets/Editor/BuildTiltBrush.cs` before building. If you didn't, your app won't be built with those scenes even if they are put on `Scenes In Build` in `Build Settings`.
+
 ### Publishing to Oculus stores
 
 Follow these steps to publish to Oculus stores:

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Follow these steps to build your app for Oculus Quest:
     `../Builds/OculusMobile_Release_OpenBrush_FromGui/`.
 1.  Run `adb install com.Icosa.OpenBrush.apk`.
 
-**Note:** Add your new scene files' names in List '`scene`' on 1221st line in `../Assets/Editor/BuildTiltBrush.cs` before building. If you didn't, your app won't be built with those scenes even if they are put on `Scenes In Build` in `Build Settings`.
+**Note:** Add your new scene files' names to the list **scenes** defined in the **DoBuild** method (string[] scenes = {...} ) in `BuildTiltBrush.cs` under  `../Assets/Editor/` before building. If you didn't, your app won't be built with those scenes even if they are put on `Scenes In Build` in `Build Settings`.
 
 ### Publishing to Oculus stores
 


### PR DESCRIPTION
This PR is for building own app with other scenes added for beginners.

### Changes
- `README` - Add explanation about 'the way to build with new scenes added for beginner developers' in `Building your app for Oculus Quest` step.
- `BuildTiltBrush.cs` - Add explanation about 'the way to build with new scenes added for beginner developers' on 1221st line.
---
I'm a student making a project with `Open Brush` as an Open Brush sample project.
While making a new project, one of the most difficult things to solve was finding a way to add my new scenes in this project.
In the case of building in the way README file is letting people know, `Tilt > Build > Do Build`, new scenes are never added before change `BuildTiltBrush.cs` but this document isn't explaining this problem, and this is very difficult to solve for beginners.
This project and document are awesome, but I think the document should be more beginner friendly.
I really like this project and I hope the sample project I will make to be able to contributes to this project. At the same time, I hope many novice developers can use this project to create many new projects with the revised document. Thank you !