### PR TITLE
Readme: Fix dead link for Tilt Shift effect source

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ open-source licensing issues. These are:
 *   **Tilt Shift**. The official Tilt Brush app uses modified versions of the
     Tilt Shift effect that came with the standard assets in earlier versions of
     Unity. These have been replaced with a modified version of
-    [Tilt shift by underscorediscovery](https://gist.github.com/underscorediscovery/10324388).
+    [Tilt shift by ruby0x1](https://gist.github.com/ruby0x1/10324388).
 
 ## Generating Secrets file
 Credentials for services such as Google and Sketchfab are stored in a `SecretsConfig` scriptable object. This has been ignored in the git config for safety. To add it back:


### PR DESCRIPTION
underscorediscovery now goes by ruby0x1. You can verify this at their
old gist page or website commented in the shader (TiltShift.shader):
https://gist.github.com/underscorediscovery/
http://notes.underscorediscovery.com/

Update link to point to their current tilt.shift.glsl gist which is mostly
similar to TiltShift.shader.