### PR TITLE
Remove / in build identifier (messes with directory names)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
               DESCRIPTION="Unknown"
             fi
             echo "::set-output name=description::-btb-description ${DESCRIPTION}"
-            IDENTIFIER=$(echo ${DESCRIPTION} | sed -e 's/[#_-]//g')
+            IDENTIFIER=$(echo ${DESCRIPTION} | sed -e 's/[\/#_-]//g')
             echo "::set-output name=basename::OpenBrush-${IDENTIFIER}"
           fi
   build:


### PR DESCRIPTION
Bad: `-btb-out /github/workspace/build/StandaloneLinux64-SteamVR/OpenBrush-features/betterbuildnames`
Good: `-btb-out /github/workspace/build/StandaloneLinux64-SteamVR/OpenBrush-featuresbetterbuildnames`
(well, relatively good, I suppose)