### PR TITLE
Support Oculus MRC moving camera

### DIFF
--- a/Assets/Scripts/OculusMRCCameraUpdate.cs
+++ b/Assets/Scripts/OculusMRCCameraUpdate.cs
@@ -32,7 +32,7 @@ public class OculusMRCCameraUpdate : MonoBehaviour {
       OVRPlugin.CameraIntrinsics cameraIntrinsics;
       OVRPlugin.CameraExtrinsics cameraExtrinsics;
 
-      OVRPlugin.OverrideExternalCameraStaticPose(0, false, OVRPose.identity); // or OVRPlugin.ResetDefaultExternalCamera();
+      OVRPlugin.OverrideExternalCameraStaticPose(0, false, OVRPose.identity.ToPosef()); // or OVRPlugin.ResetDefaultExternalCamera();
       
       if (OVRPlugin.GetMixedRealityCameraInfo(0, out cameraExtrinsics, out cameraIntrinsics)) {
         calibratedCameraPose = cameraExtrinsics.RelativePose.ToOVRPose();

--- a/Assets/Scripts/OculusMRCCameraUpdate.cs
+++ b/Assets/Scripts/OculusMRCCameraUpdate.cs
@@ -24,21 +24,19 @@ public class OculusMRCCameraUpdate : MonoBehaviour {
   private OVRPose? calibratedCameraPose = null;
 
   void Update() {
-    if (!calibratedCameraPose.HasValue) {
-      if (!OVRPlugin.Media.GetInitialized()) {
-        return;
-      }
+    if (!OVRPlugin.Media.GetInitialized()) {
+      return;
+    }
 
-      OVRPlugin.CameraIntrinsics cameraIntrinsics;
-      OVRPlugin.CameraExtrinsics cameraExtrinsics;
+    OVRPlugin.CameraIntrinsics cameraIntrinsics;
+    OVRPlugin.CameraExtrinsics cameraExtrinsics;
 
-      OVRPlugin.OverrideExternalCameraStaticPose(0, false, OVRPose.identity.ToPosef()); // or OVRPlugin.ResetDefaultExternalCamera();
+    // OVRPlugin.OverrideExternalCameraStaticPose(0, false, OVRPose.identity.ToPosef()); // or OVRPlugin.ResetDefaultExternalCamera();
       
-      if (OVRPlugin.GetMixedRealityCameraInfo(0, out cameraExtrinsics, out cameraIntrinsics)) {
-        calibratedCameraPose = cameraExtrinsics.RelativePose.ToOVRPose();
-      } else {
-        return;
-      }
+    if (OVRPlugin.GetMixedRealityCameraInfo(0, out cameraExtrinsics, out cameraIntrinsics)) {
+      calibratedCameraPose = cameraExtrinsics.RelativePose.ToOVRPose();
+    } else {
+      return;
     }
 
     OVRPose cameraStagePoseInUnits = calibratedCameraPose.Value;

--- a/Assets/Scripts/OculusMRCCameraUpdate.cs
+++ b/Assets/Scripts/OculusMRCCameraUpdate.cs
@@ -32,6 +32,8 @@ public class OculusMRCCameraUpdate : MonoBehaviour {
       OVRPlugin.CameraIntrinsics cameraIntrinsics;
       OVRPlugin.CameraExtrinsics cameraExtrinsics;
 
+      OVRPlugin.OverrideExternalCameraStaticPose(0, false, OVRPose.identity); // or OVRPlugin.ResetDefaultExternalCamera();
+      
       if (OVRPlugin.GetMixedRealityCameraInfo(0, out cameraExtrinsics, out cameraIntrinsics)) {
         calibratedCameraPose = cameraExtrinsics.RelativePose.ToOVRPose();
       } else {

--- a/Assets/Scripts/OculusMRCCameraUpdate.cs
+++ b/Assets/Scripts/OculusMRCCameraUpdate.cs
@@ -31,7 +31,7 @@ public class OculusMRCCameraUpdate : MonoBehaviour {
     OVRPlugin.CameraIntrinsics cameraIntrinsics;
     OVRPlugin.CameraExtrinsics cameraExtrinsics;
 
-    OVRPlugin.OverrideExternalCameraStaticPose(0, false, OVRPose.identity.ToPosef()); // or OVRPlugin.ResetDefaultExternalCamera();
+    OVRPlugin.OverrideExternalCameraStaticPose(0, false, OVRPose.identity.ToPosef());
       
     if (OVRPlugin.GetMixedRealityCameraInfo(0, out cameraExtrinsics, out cameraIntrinsics)) {
       calibratedCameraPose = cameraExtrinsics.RelativePose.ToOVRPose();

--- a/Assets/Scripts/OculusMRCCameraUpdate.cs
+++ b/Assets/Scripts/OculusMRCCameraUpdate.cs
@@ -31,7 +31,7 @@ public class OculusMRCCameraUpdate : MonoBehaviour {
     OVRPlugin.CameraIntrinsics cameraIntrinsics;
     OVRPlugin.CameraExtrinsics cameraExtrinsics;
 
-    // OVRPlugin.OverrideExternalCameraStaticPose(0, false, OVRPose.identity.ToPosef()); // or OVRPlugin.ResetDefaultExternalCamera();
+    OVRPlugin.OverrideExternalCameraStaticPose(0, false, OVRPose.identity.ToPosef()); // or OVRPlugin.ResetDefaultExternalCamera();
       
     if (OVRPlugin.GetMixedRealityCameraInfo(0, out cameraExtrinsics, out cameraIntrinsics)) {
       calibratedCameraPose = cameraExtrinsics.RelativePose.ToOVRPose();


### PR DESCRIPTION
I've made a small change to `OculusMRCCameraUpdate` to allow us to continue getting the Mixed Reality camera updates (from the network) instead of just using the first camera pose (from the `mrc.xml` file).

cc @mikeskydev @giantsox