### PR TITLE
Add an OVRCameraRig to the VrSystem object for MRC on Quest

### DIFF
--- a/Assets/Scripts/VrSdk.cs
+++ b/Assets/Scripts/VrSdk.cs
@@ -197,7 +197,10 @@ namespace TiltBrush
                 m_VrCamera.gameObject.AddComponent<OculusCameraFade>();
                 m_VrCamera.gameObject.AddComponent<OculusPreCullHook>();
 
-                gameObject.AddComponent<OculusMRCCameraUpdate>();
+                //Add an OVRCameraRig to the VrSystem for Mixed Reality Capture.
+                var cameraRig = m_VrSystem.AddComponent<OVRCameraRig>();
+                //Disable the OVRCameraRig's eye cameras, since Open Brush already has its own.
+                cameraRig.disableEyeAnchorCameras = true;
 #endif // OCULUS_SUPPORTED
             }
             else if (App.Config.m_SdkMode == SdkMode.SteamVR)


### PR DESCRIPTION
Open Brush currently uses the `OculusMRCCameraUpdate` script that obtains the mixed reality camera pose from the Oculus SDK, converts it back into the stage coordinate space that the Oculus uses internally, scales it by 10x, then tells the Oculus SDK to use the scaled pose for the mixed reality camera.

This script also had a small bug where this calculation was only done once, so if the physical camera moves, the virtual camera would be positioned incorrectly. Instead, I add an OVRCameraRig to the VrSystem GameObject, which is already scaled properly, as recommended by the Oculus documentation. 


https://www.youtube.com/watch?v=ZDZwRU1mIfk