### PR TITLE
Fix an error importing some Sketchfab gltf files

### DIFF
--- a/Assets/ThirdParty/TiltBrushToolkit/Scripts/Gltf/GltfMaterialConverter.cs
+++ b/Assets/ThirdParty/TiltBrushToolkit/Scripts/Gltf/GltfMaterialConverter.cs
@@ -409,7 +409,7 @@ public class GltfMaterialConverter {
   private static IEnumerable ConvertTextureCoroutine(
       GltfTextureBase gltfTexture, IUriLoader loader) {
     if (gltfTexture.unityTexture != null) {
-      throw new InvalidOperationException("Already converted");
+      Debug.LogWarning($"Texture already converted: {gltfTexture.unityTexture.name}");
     }
 
     if (gltfTexture.SourcePtr == null) {


### PR DESCRIPTION
Example file: https://sketchfab.com/3d-models/persimon-whole-cut-and-seed-346d0b5a95c94c2890dbff3b38984719 (download as "gltf converted" and import via the media library). In general I think "try as hard as possible to import without throwing an error" is probably a good import strategy.