### PR TITLE
Pin dotnet-format to 5.1.225507

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,4 +14,13 @@ jobs:
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '3.1.x'
+      - name: "HACK: manually install dotnet-format into pre-commit's cache"
+        run: |
+          pip install pre-commit
+          set +e
+          pre-commit run dotnet-format # This will fail, so ignore it, but we need it to create the "random" directory for the dotnet-format
+          set -e
+          PRE_COMMIT_PATH="$(echo 'SELECT path FROM repos WHERE repo == "https://github.com/dotnet/format";' | sqlite3 ~/.cache/pre-commit/db.db)/dotnetenv-default/bin"
+          dotnet tool install dotnet-format --tool-path $PRE_COMMIT_PATH --version 5.1.225507
+          echo '{"additional_dependencies": []}' > $PRE_COMMIT_PATH/../.install_state_v1
       - uses: pre-commit/action@v2.0.0


### PR DESCRIPTION
The latest dotnet-format is 7.0.x and does not run with .NET 3.1.2 or 5.x, which is the stable release. We could move to a preview release, but there are two open issues on dotnet format; see 1317 and 1318 at their repo.

However, the way pre-commit handles dotnet packages, it always installs the latest version (dotnet tool install ...). There is no way to specify a specific version.

So we have this charming hack to trick pre-commit into using our manually installed version.