### PR TITLE
Alter progress shader for OB logo

### DIFF
--- a/Assets/Shaders/TiltBrushLogo_Progress.shader
+++ b/Assets/Shaders/TiltBrushLogo_Progress.shader
@@ -73,51 +73,54 @@ Shader "Custom/TiltBrushLogo_Progress" {
         const float PI_OVER_THREE = 3.14159265358979 / 3.0;
         float x = IN.uv_MainTex.x - 0.5;
         float y = IN.uv_MainTex.y - 0.5;
-        float theta = fmod(atan2(x, y) + TWO_PI, TWO_PI);
+        float theta = fmod(atan2(x , y) + TWO_PI - TWO_PI/21, TWO_PI);
   
+        // The commented code below was used to progress the Tilt Brush logo correctly.
+        // As Open Brush's logo is radial, this is not needed.
+
         // Modify theta so that the first sixth of the progress sweeps across the first part of the
         // logo.
-        const float A_MIN = 0.600;  // Left edge of the first part of the logo
-        const float A_MAX = 1.100;  // Right edge of the first part of the logo
-        const float B_MIN = 0.515;  // Top edge of the first part of the logo
-        const float B_MAX = 0.682;  // Bottom edge of the first part of the logo
-        const float cos_30 = 0.86602540378443864676372317075294;
-        const float sin_30 = 0.5;
-        float a = IN.uv_MainTex.x * sin_30 + IN.uv_MainTex.y * cos_30;
-        a = (a - A_MIN) / (A_MAX - A_MIN);
-        float b = IN.uv_MainTex.x * sin_30 + (1 - IN.uv_MainTex.y) * cos_30;
-        b = (b - B_MIN) / (B_MAX - B_MIN);
+        // const float A_MIN = 0.600;  // Left edge of the first part of the logo
+        // const float A_MAX = 1.100;  // Right edge of the first part of the logo
+        // const float B_MIN = 0.515;  // Top edge of the first part of the logo
+        // const float B_MAX = 0.682;  // Bottom edge of the first part of the logo
+        // const float cos_30 = 0.86602540378443864676372317075294;
+        // const float sin_30 = 0.5;
+        // float a = IN.uv_MainTex.x * sin_30 + IN.uv_MainTex.y * cos_30;
+        // a = (a - A_MIN) / (A_MAX - A_MIN);
+        // float b = IN.uv_MainTex.x * sin_30 + (1 - IN.uv_MainTex.y) * cos_30;
+        // b = (b - B_MIN) / (B_MAX - B_MIN);
   
-        // Interpolate between the three different colors in the first 1/6th of the logo.
-        const float edge1 = 1.0 / 18;
-        const float factor1 = _Progress / edge1;
-        const float edge2 = 1.0 / 9;
-        const float factor2 = (_Progress - edge1) / (edge2 - edge1);
-        const float factor2b = -5 * (1 - factor2) + 1 * factor2;
-        const float edge3 = 1.0 / 6;
-        const float factor3 = (_Progress - edge2) / (edge3 - edge2);
-        float e1 = _Progress < edge1 ? 6.65 * (1 - factor1) + 5.00 * factor1 :
-                   _Progress < edge2 ? 5.00 * (1 - factor2) + 3.30 * factor2 : 3.30 * (1 - factor3);
-        float e2 = _Progress < edge1 ? 3.33 * (1 - factor1) + 3.30 * factor1 :
-                   _Progress < edge2 ? 3.30 * (1 - factor2) + 0.00 * factor2 : 0.00 * (1 - factor3);
-        float e3 = _Progress < edge1 ? 0.00 * (1 - factor1) + 0.00 * factor1 :
-                   _Progress < edge2 ? 0.00 * (1 - factor2) + 1.60 * factor2 : 1.60 * (1 - factor3);
-        float e4 = _Progress < edge1 ? 3.33 * (1 - factor1) + 5.00 * factor1 :
-                   _Progress < edge2 ? 5.00 * (1 - factor2) + 1.60 * factor2 : 1.60 * (1 - factor3);
-        float taper =
-            b < 1.0 / 8 ? smooth(-e1 - 2, -e1, .5 + 4 * b) :
-            b < 2.0 / 8 ? smooth(-e1, -e2, 4 * b - 0.5) :
-            b < 3.0 / 8 ? smooth(-e1, -e2, 4 * b - 0.5) :
-            b < 4.0 / 8 ? smooth(-e2, -e3, 4 * b - 1.5) :
-            b < 5.0 / 8 ? smooth(-e2, -e3, 4 * b - 1.5) :
-            b < 6.0 / 8 ? smooth(-e3, -e4, 4 * b - 2.5) :
-            b < 7.0 / 8 ? smooth(-e3, -e4, 4 * b - 2.5) :
-                          smooth(-e4, -e4 - 1, 4 * b - 3.5);
-        taper *= 0.05;
+        // // Interpolate between the three different colors in the first 1/6th of the logo.
+        // const float edge1 = 1.0 / 18;
+        // const float factor1 = _Progress / edge1;
+        // const float edge2 = 1.0 / 9;
+        // const float factor2 = (_Progress - edge1) / (edge2 - edge1);
+        // const float factor2b = -5 * (1 - factor2) + 1 * factor2;
+        // const float edge3 = 1.0 / 6;
+        // const float factor3 = (_Progress - edge2) / (edge3 - edge2);
+        // float e1 = _Progress < edge1 ? 6.65 * (1 - factor1) + 5.00 * factor1 :
+        //            _Progress < edge2 ? 5.00 * (1 - factor2) + 3.30 * factor2 : 3.30 * (1 - factor3);
+        // float e2 = _Progress < edge1 ? 3.33 * (1 - factor1) + 3.30 * factor1 :
+        //            _Progress < edge2 ? 3.30 * (1 - factor2) + 0.00 * factor2 : 0.00 * (1 - factor3);
+        // float e3 = _Progress < edge1 ? 0.00 * (1 - factor1) + 0.00 * factor1 :
+        //            _Progress < edge2 ? 0.00 * (1 - factor2) + 1.60 * factor2 : 1.60 * (1 - factor3);
+        // float e4 = _Progress < edge1 ? 3.33 * (1 - factor1) + 5.00 * factor1 :
+        //            _Progress < edge2 ? 5.00 * (1 - factor2) + 1.60 * factor2 : 1.60 * (1 - factor3);
+        // float taper =
+        //     b < 1.0 / 8 ? smooth(-e1 - 2, -e1, .5 + 4 * b) :
+        //     b < 2.0 / 8 ? smooth(-e1, -e2, 4 * b - 0.5) :
+        //     b < 3.0 / 8 ? smooth(-e1, -e2, 4 * b - 0.5) :
+        //     b < 4.0 / 8 ? smooth(-e2, -e3, 4 * b - 1.5) :
+        //     b < 5.0 / 8 ? smooth(-e2, -e3, 4 * b - 1.5) :
+        //     b < 6.0 / 8 ? smooth(-e3, -e4, 4 * b - 2.5) :
+        //     b < 7.0 / 8 ? smooth(-e3, -e4, 4 * b - 2.5) :
+        //                   smooth(-e4, -e4 - 1, 4 * b - 3.5);
+        // taper *= 0.05;
   
-        theta = a > 0 && a < 1 && b > 0 && b < 1
-            ? (a + taper) * PI_OVER_THREE
-            : theta;
+        // theta = a > 0 && a < 1 && b > 0 && b < 1
+        //     ? (a + taper) * PI_OVER_THREE
+        //     : theta;
   
         fixed4 c = tex2D(_MainTex, IN.uv_MainTex);
         c *= _Color * theta < (_Progress * TWO_PI) ? 1 : 0.75;


### PR DESCRIPTION
The shader displaying the loading progress was designed specifically for the Tilt Brush logo. However this doesn't work with the Open Brush logo. The shader has been simplified to work better with the Open Brush logo.

Before:
![image](https://user-images.githubusercontent.com/9121007/139596294-7d5c675b-a7ed-4481-b259-03daf86e3e03.png)

After:
![image](https://user-images.githubusercontent.com/9121007/139596308-e0a17e07-e668-4ae1-933c-09257f596aa3.png)
