### PR TITLE
Revert "Prevent more than one build at a time on a given branch. Will prevent merge timing bugs"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@
 ---
 name: Builds
 
-concurrency: build-{{ github.ref }}
-
 on:  # yamllint disable-line rule:truthy
   pull_request: {}
   push:


### PR DESCRIPTION
Reverts icosa-gallery/open-brush#207

Github doesn't handle more than one pending job. This makes this unsuitable for our purposes. (There was also a missing $, but even with that done properly, the current behavior which only allows one pending action is insufficient)