### PR TITLE
Fixed video reference on quest 2

### DIFF
--- a/Assets/Scripts/ReferenceVideo.cs
+++ b/Assets/Scripts/ReferenceVideo.cs
@@ -267,7 +267,7 @@ namespace TiltBrush
                 else
                 {
                     string fullPath = System.IO.Path.Combine(App.VideoLibraryPath(), PersistentPath);
-                    m_VideoPlayer.url = $"file:///{fullPath}";
+                    m_VideoPlayer.url = $"{fullPath}";
                 }
                 m_VideoPlayer.isLooping = true;
                 m_VideoPlayer.renderMode = VideoRenderMode.APIOnly;


### PR DESCRIPTION
It seems that one of the os updates on quest 2 broke the video playback in media library.
I saw multiple threads on similar issues and it looks like android 10 handles file access differently than on previous version.
https://forum.unity.com/threads/error-videoplayer-on-android.742451/#post-5028434
https://issuetracker.unity3d.com/issues/android-video-player-cannot-play-files-located-in-the-persistent-data-directory-on-android-10