### PR TITLE
Fix invisible camera viewfinder when no posteffects

### DIFF
--- a/Assets/Shaders/SnapshotCameraFlash.shader
+++ b/Assets/Shaders/SnapshotCameraFlash.shader
@@ -73,6 +73,7 @@ Shader "Unlit/Snapshot Camera Flash"
                 col.a *= _Alpha;
                 // apply fog
                 UNITY_APPLY_FOG(i.fogCoord, col);
+                col.a = 1.0;
                 return col;
             }
             ENDCG


### PR DESCRIPTION
Fixes #45, at least in the viewfinder. This may be part of a bigger set of issues related to the postprocessing shader stack, but this will restore the viewfinder functionality for now!