### PR TITLE
Add workflow to generate the unity license file for the embedded license (non formal PRs)

### DIFF
--- a/.github/workflows/get_license.yml
+++ b/.github/workflows/get_license.yml
@@ -10,7 +10,7 @@ jobs:
       # Request manual activation file
       - name: Request manual activation file
         id: getManualLicenseFile
-        uses: game-ci/unity-request-activation-file@v2.0-alpha-1
+        uses: game-ci/unity-request-activation-file@v2
         with:
           unityVersion: 2019.4.25f1
       # Upload artifact (Unity_v20XX.X.XXXX.alf)

--- a/.github/workflows/get_license.yml
+++ b/.github/workflows/get_license.yml
@@ -1,0 +1,21 @@
+name: Acquire activation file
+on:
+  workflow_dispatch:
+
+jobs:
+  activation:
+    name: Request manual activation file 🔑
+    runs-on: ubuntu-latest
+    steps:
+      # Request manual activation file
+      - name: Request manual activation file
+        id: getManualLicenseFile
+        uses: game-ci/unity-request-activation-file@v2.0-alpha-1
+        with:
+          unityVersion: 2019.4.25f1
+      # Upload artifact (Unity_v20XX.X.XXXX.alf)
+      - name: Expose as artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ steps.getManualLicenseFile.outputs.filePath }}
+          path: ${{ steps.getManualLicenseFile.outputs.filePath }}


### PR DESCRIPTION
This workflow is triggered manually, and can be used to create the files
needed to store a license in the build.yaml. This license contains the
credentials used for non-official builds; i.e., PR builds, and builds on
forks that do not have the secrets defined for using a real license.

If you want to create your own file, or need to move to a newer major
Unity release, follow the instructions at https://game.ci/docs/github/activation