### PR TITLE
Disable custom keystore in repo; enable it for all CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -309,6 +309,10 @@ jobs:
           SECRETS_ASSET_META_GUID=$(grep "guid:" Assets/Secrets.asset.meta | cut -d" " -f2)
           sed -e "s/Secrets:.*$/Secrets: {fileID: 11400000, guid: $SECRETS_ASSET_META_GUID, type: 2}/" -i Assets/Scenes/Main.unity
 
+      - name: Enable keystore
+        run: |
+          sed -e 's/androidUseCustomKeystore.*$/androidUseCustomKeystore: 1/' -i ProjectSettings/ProjectSettings.asset
+
       - name: Build project
         uses: game-ci/unity-builder@v2.0-alpha-13
         env:

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -263,7 +263,7 @@ PlayerSettings:
   AndroidEnableTango: 0
   androidEnableBanner: 1
   androidUseLowAccuracyLocation: 0
-  androidUseCustomKeystore: 1
+  androidUseCustomKeystore: 0
   m_AndroidBanners:
   - width: 320
     height: 180


### PR DESCRIPTION
In #217, it was enabled in the ProjectSettings file. However, this broke
local compilation, since the keystore was not available for repo
clones/forks.

It's better to leave it disabled, and just enabled it in all CI builds
(where we use either the real keystore for formal builds, or our fake
one for PRs)