### PR TITLE
Add Android OpenXR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,10 @@ jobs:
             targetPlatform: StandaloneWindows64
             vrsdk: Oculus
             extraoptions: -btb-experimental
+          - name: Android OpenXR
+            targetPlatform: Android
+            vrsdk: OpenXR
+            extraoptions: -setDefaultPlatformTextureFormat astc -btb-il2cpp
           - name: Oculus Quest
             targetPlatform: Android
             vrsdk: Oculus

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -750,7 +750,7 @@ PlayerSettings:
   webGLThreadsSupport: 0
   webGLDecompressionFallback: 0
   scriptingDefineSymbols:
-    Android: TILT_BRUSH;OCULUS_SUPPORTED
+    Android: TILT_BRUSH
     Standalone: USD_SUPPORTED;UNITY_HAS_GOOGLEVR;TILT_BRUSH;FBX_SUPPORTED;FBXSDK_RUNTIME;LATK_SUPPORTED
     Windows Store Apps: USD_SUPPORTED;UNITY_HAS_GOOGLEVR;TILT_BRUSH
   additionalCompilerArguments: {}


### PR DESCRIPTION
- Add generic OpenXR on Android
- Removes `OCULUS_SUPPORTED` from Android scripting define symbols. CI will add this automatically.