### PR TITLE
Oculus via Unity OpenXR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,9 +180,9 @@ jobs:
       - name: Install Oculus unity package
         if: matrix.vrsdk == 'Oculus'
         run: |
-          # version 38.0
+          # version 39.0
           # Code courtesy of Jonathan Perret, released freely. Download the package and manually extract it to Assets/Oculus. We only need VR and Platform.
-          wget -q https://securecdn.oculus.com/binaries/download/?id=5029409037101874 -O package.tmp
+          wget -q https://securecdn.oculus.com/binaries/download/?id=5124847327558044 -O package.tmp
           mkdir tmp
           tar -C tmp -xzf package.tmp
           find tmp -type f | xargs chmod a-x
@@ -230,14 +230,6 @@ jobs:
           key: Library-${{ matrix.targetPlatform }}-${{ env.UNITY_VERSION }}
           restore-keys: |
             Library-${{ matrix.targetPlatform }}-
-
-      - name: Manually delete OpenXR packages
-        if: matrix.vrsdk == 'Oculus'
-        run: |
-          cat Packages/manifest.json | jq 'del( .dependencies ["com.unity.xr.openxr"] )' | tee Packages/manifest.json.new
-          mv Packages/manifest.json.new Packages/manifest.json
-          cat Packages/packages-lock.json | jq 'del( .dependencies ["com.unity.xr.openxr"] )' | tee Packages/packages-lock.json.new
-          mv Packages/packages-lock.json.new Packages/packages-lock.json
 
       - name: Update Oculus OVR Plugin
         uses: game-ci/unity-builder@v2

--- a/Assets/Editor/BuildTiltBrush.cs
+++ b/Assets/Editor/BuildTiltBrush.cs
@@ -857,7 +857,7 @@ static class BuildTiltBrush
             target = BuildTarget.StandaloneWindows64;
         }
 
-        if(target == BuildTarget.Android)
+        if (target == BuildTarget.Android)
         {
             EditorUserBuildSettings.androidCreateSymbols = AndroidCreateSymbols.Debugging;
         }
@@ -997,11 +997,11 @@ static class BuildTiltBrush
             m_targetGroup = TargetToGroup(tiltOptions.Target);
             UnityEditor.XR.OpenXR.Features.FeatureHelpers.RefreshFeatures(m_targetGroup);
 
-            switch(tiltOptions.XrSdk)
+            switch (tiltOptions.XrSdk)
             {
                 case XrSdkMode.Oculus:
                     requiredFeatures.Add("com.oculus.openxr.feature.oculusxr");
-                    if(m_targetGroup == BuildTargetGroup.Android)
+                    if (m_targetGroup == BuildTargetGroup.Android)
                     {
                         requiredFeatures.Add("com.unity.openxr.feature.oculusquest");
                     }
@@ -1009,12 +1009,15 @@ static class BuildTiltBrush
             }
 
             // Locate and enable features, fail if not found.
-            foreach(string requiredFeature in requiredFeatures)
+            foreach (string requiredFeature in requiredFeatures)
             {
                 var foundFeature = UnityEditor.XR.OpenXR.Features.FeatureHelpers.GetFeatureWithIdForBuildTarget(m_targetGroup, requiredFeature);
-                if(foundFeature == null)
+                if (foundFeature == null)
+                {
                     Die(6, "Could not find required OpenXR Feature \"{0}\"", requiredFeature);
-                if(!foundFeature.enabled)
+                }
+
+                if (!foundFeature.enabled)
                 {
                     // TODO: This is as good as we can do without the API suggested below to 'restore' the state.
                     m_FeaturesNotEnabled.Add(foundFeature);
@@ -1028,7 +1031,7 @@ static class BuildTiltBrush
 
         public void Dispose()
         {
-            foreach(var feature in m_FeaturesNotEnabled)
+            foreach (var feature in m_FeaturesNotEnabled)
             {
                 feature.enabled = false;
             }
@@ -1044,11 +1047,11 @@ static class BuildTiltBrush
         {
             string[] targetXrPluginsRequired;
 
-            switch(tiltOptions.XrSdk)
+            switch (tiltOptions.XrSdk)
             {
                 case XrSdkMode.Oculus:
                 case XrSdkMode.OpenXR:
-                    targetXrPluginsRequired = new string[] {"UnityEngine.XR.OpenXR.OpenXRLoader"};
+                    targetXrPluginsRequired = new string[] { "UnityEngine.XR.OpenXR.OpenXRLoader" };
                     break;
                 default:
                     return;

--- a/Assets/Scripts/VrSdk.cs
+++ b/Assets/Scripts/VrSdk.cs
@@ -501,7 +501,7 @@ namespace TiltBrush
 #if OCULUS_SUPPORTED
                 // N points, clockwise winding (but axis is undocumented), undocumented convexity
                 // In practice, it's clockwise looking along Y-
-                points_RS = OVRManager.boundary.GetGeometry(OVRBoundary.BoundaryType.OuterBoundary)
+                points_RS = OVRManager.boundary.GetGeometry(OVRBoundary.BoundaryType.PlayArea)
                     .Select(v => UnityFromOculus(v)).ToArray();
 #else // OCULUS_SUPPORTED
             // if (App.Config.m_SdkMode == SdkMode.SteamVR)
@@ -1300,7 +1300,7 @@ namespace TiltBrush
             Debug.Assert(level >= 0 && level <= 3);
             if (App.Config.IsMobileHardware && !SpoofMobileHardware.MobileHardware)
             {
-                OVRManager.tiledMultiResLevel = (OVRManager.TiledMultiResLevel)level;
+                OVRManager.fixedFoveatedRenderingLevel = (OVRManager.FixedFoveatedRenderingLevel)level;
             }
 #endif // OCULUS_SUPPORTED
         }
@@ -1322,7 +1322,7 @@ namespace TiltBrush
 #if OCULUS_SUPPORTED
             if (App.Config.IsMobileHardware)
             {
-                OVRManager.gpuLevel = level;
+                OVRManager.suggestedGpuPerfLevel = (OVRManager.ProcessorPerformanceLevel)level;
             }
 #endif // OCULUS_SUPPORTED
         }

--- a/Assets/XR/Settings/Open XR Package Settings.asset
+++ b/Assets/XR/Settings/Open XR Package Settings.asset
@@ -20,6 +20,37 @@ MonoBehaviour:
   company: Unity
   priority: 0
   required: 0
+--- !u!114 &-8632917095941882487
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1927c045052a06d49a9b21fdcaa26db6, type: 3}
+  m_Name: OculusXRFeature Standalone
+  m_EditorClassIdentifier: 
+  m_enabled: 0
+  nameUi: OculusXR Feature
+  version: 0.0.1
+  featureIdInternal: com.oculus.openxr.feature.oculusxr
+  openxrExtensionStrings: 'XR_KHR_vulkan_enable XR_KHR_D3D11_enable XR_OCULUS_common_reference_spaces
+    XR_FB_display_refresh_rate XR_EXT_performance_settings XR_FB_composition_layer_image_layout
+    XR_KHR_android_surface_swapchain XR_FB_android_surface_swapchain_create XR_KHR_composition_layer_color_scale_bias
+    XR_FB_color_space XR_EXT_hand_tracking XR_FB_swapchain_update_state XR_FB_swapchain_update_state_opengl_es
+    XR_FB_swapchain_update_state_vulkan XR_FB_foveation XR_FB_foveation_configuration
+    XR_FB_foveation_vulkan XR_FB_composition_layer_alpha_blend XR_KHR_composition_layer_depth
+    XR_KHR_composition_layer_cylinder XR_KHR_composition_layer_cube XR_KHR_composition_layer_equirect2
+    XR_KHR_convert_timespec_time XR_KHR_visibility_mask XR_FB_render_model XR_FB_spatial_entity
+    XR_FB_spatial_entity_query XR_FB_spatial_entity_storage XR_FB_keyboard_tracking
+    XR_FB_passthrough XR_FB_triangle_mesh XR_FB_passthrough_keyboard_hands XR_OCULUS_audio_device_guid
+    XR_FB_common_events XR_FB_space_warp XR_FB_hand_tracking_capsules XR_FB_hand_tracking_mesh
+    XR_FB_hand_tracking_aim '
+  company: Oculus
+  priority: 0
+  required: 0
 --- !u!114 &-7635896756621915544
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -263,6 +294,7 @@ MonoBehaviour:
   - {fileID: -1562417761177608366}
   - {fileID: -238312934105289492}
   - {fileID: -3768601675236611697}
+  - {fileID: 6781313199298781951}
   - {fileID: 4073621059260807014}
   m_renderMode: 0
   m_depthSubmissionMode: 0
@@ -278,7 +310,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ef793c31862a37448e907829482ef80, type: 3}
   m_Name: OculusQuestFeature Android
   m_EditorClassIdentifier: 
-  m_enabled: 1
+  m_enabled: 0
   nameUi: Oculus Quest Support
   version: 1.0.0
   featureIdInternal: com.unity.openxr.feature.oculusquest
@@ -551,6 +583,37 @@ MonoBehaviour:
   company: Unity
   priority: 0
   required: 0
+--- !u!114 &6781313199298781951
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1927c045052a06d49a9b21fdcaa26db6, type: 3}
+  m_Name: OculusXRFeature Android
+  m_EditorClassIdentifier: 
+  m_enabled: 0
+  nameUi: OculusXR Feature
+  version: 0.0.1
+  featureIdInternal: com.oculus.openxr.feature.oculusxr
+  openxrExtensionStrings: 'XR_KHR_vulkan_enable XR_KHR_D3D11_enable XR_OCULUS_common_reference_spaces
+    XR_FB_display_refresh_rate XR_EXT_performance_settings XR_FB_composition_layer_image_layout
+    XR_KHR_android_surface_swapchain XR_FB_android_surface_swapchain_create XR_KHR_composition_layer_color_scale_bias
+    XR_FB_color_space XR_EXT_hand_tracking XR_FB_swapchain_update_state XR_FB_swapchain_update_state_opengl_es
+    XR_FB_swapchain_update_state_vulkan XR_FB_foveation XR_FB_foveation_configuration
+    XR_FB_foveation_vulkan XR_FB_composition_layer_alpha_blend XR_KHR_composition_layer_depth
+    XR_KHR_composition_layer_cylinder XR_KHR_composition_layer_cube XR_KHR_composition_layer_equirect2
+    XR_KHR_convert_timespec_time XR_KHR_visibility_mask XR_FB_render_model XR_FB_spatial_entity
+    XR_FB_spatial_entity_query XR_FB_spatial_entity_storage XR_FB_keyboard_tracking
+    XR_FB_passthrough XR_FB_triangle_mesh XR_FB_passthrough_keyboard_hands XR_OCULUS_audio_device_guid
+    XR_FB_common_events XR_FB_space_warp XR_FB_hand_tracking_capsules XR_FB_hand_tracking_mesh
+    XR_FB_hand_tracking_aim '
+  company: Oculus
+  priority: 0
+  required: 0
 --- !u!114 &6812736204562946406
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -592,6 +655,7 @@ MonoBehaviour:
   - {fileID: -6553496117388817208}
   - {fileID: 3442458366111397828}
   - {fileID: 6812736204562946406}
+  - {fileID: -8632917095941882487}
   - {fileID: -7635896756621915544}
   - {fileID: -177044242218828340}
   m_renderMode: 0

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -15,7 +15,6 @@
     "com.unity.timeline": "1.6.4",
     "com.unity.ugui": "1.0.0",
     "com.unity.xr.management": "4.2.1",
-    "com.unity.xr.oculus": "3.0.1",
     "com.unity.xr.openxr": "1.3.1",
     "org.nuget.google.apis": "1.57.0",
     "org.nuget.google.apis.auth": "1.57.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -162,15 +162,6 @@
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.xr.oculus": {
-      "version": "3.0.1",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.xr.management": "4.2.0"
-      },
-      "url": "https://packages.unity.com"
-    },
     "com.unity.xr.openxr": {
       "version": "1.3.1",
       "depth": 0,


### PR DESCRIPTION
Switches Oculus to build via Unity's OpenXR rather than Oculus's custom plugin 🎉

- Removes Oculus' plugin from the package manager.
- update to v39 of the Oculus SDK to enable the new OpenXR Feature.
- new IDisposable for managing OpenXR features.