### PR TITLE
Fix: Temporarily remove YouTube scopes

### DIFF
--- a/Assets/Prefabs/HttpServer.prefab
+++ b/Assets/Prefabs/HttpServer.prefab
@@ -52,9 +52,7 @@ MonoBehaviour:
   - https://www.googleapis.com/auth/vrassetdata.readonly
   - https://www.googleapis.com/auth/drive.file
   - https://www.googleapis.com/auth/drive.appdata
-  m_AdditionalDesktopOAuthScopes:
-  - https://www.googleapis.com/auth/youtube.upload
-  - https://www.googleapis.com/auth/youtube.readonly
+  m_AdditionalDesktopOAuthScopes: []
   m_CallbackPath: /authorize
   m_LoggedInTexture: {fileID: 2800000, guid: 0d05cda193064458a9a7bb085905c5a1, type: 3}
   m_TokenStorePrefix: GoogleOAuth2


### PR DESCRIPTION
Login on desktop has been broken for too long while waiting on #232. This PR temporarily removes the YouTube additional scopes allowing the functionality to be restored. Will revert this commit as part of #232 instead.