### PR TITLE
Fix for groups bug

### DIFF
--- a/Assets/Scripts/Save/SketchWriter.cs
+++ b/Assets/Scripts/Save/SketchWriter.cs
@@ -329,7 +329,10 @@ namespace TiltBrush
 
             // stopwatch.Stop();
             // Debug.LogFormat("Reading took {0}", stopwatch.Elapsed);
-            GroupManager.MoveStrokesToNewGroups(strokes, oldGroupToNewGroup);
+            if (bAdditive)
+            {
+                GroupManager.MoveStrokesToNewGroups(strokes, oldGroupToNewGroup);
+            }
             return true;
         }
 


### PR DESCRIPTION
Groups with both strokes and models in them were splitting into separate groups after save/load. This bug was introduced by the merge strokes feature.