### PR TITLE
Remove reference to Valve Newtonsoft 

### DIFF
--- a/Assets/Scripts/API/ApiManager.cs
+++ b/Assets/Scripts/API/ApiManager.cs
@@ -25,7 +25,6 @@ using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 using UnityEngine.Networking;
-using Valve.Newtonsoft.Json.Utilities;
 
 namespace TiltBrush
 {

--- a/Assets/Scripts/API/CollectionUtils.cs
+++ b/Assets/Scripts/API/CollectionUtils.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace TiltBrush
+{
+    internal static class CollectionUtils
+    {
+        public static void AddRange<T>(this IList<T> initial, IEnumerable<T> collection)
+        {
+            if (initial == null)
+                throw new ArgumentNullException(nameof(initial));
+            if (collection == null)
+                return;
+            foreach (T obj in collection)
+                initial.Add(obj);
+        }
+    }
+}

--- a/Assets/Scripts/API/CollectionUtils.cs.meta
+++ b/Assets/Scripts/API/CollectionUtils.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d75c3b2ee2b546969def2e7096f48b4e
+timeCreated: 1660223226


### PR DESCRIPTION
We were referencing Valve's Newtonsoft just for a single extension method