### PR TITLE
Correct color picker visual from gamma to linear

### DIFF
--- a/Assets/Shaders/ColorPicker.shader
+++ b/Assets/Shaders/ColorPicker.shader
@@ -18,6 +18,10 @@ Shader "Custom/ColorPicker" {
     _MainTex ("Base (RGB)", 2D) = "white" {}
     _Cutoff ("Alpha cutoff", Range(0,1)) = 0.5
   }
+  CGINCLUDE
+    #include "Assets/Shaders/Include/ColorSpaceConvert.cginc"
+  ENDCG
+
   SubShader {
     Tags {"Queue"="AlphaTest+20" "IgnoreProjector"="True" "RenderType"="TransparentCutout"}
 
@@ -37,7 +41,7 @@ Shader "Custom/ColorPicker" {
     void surf (Input IN, inout SurfaceOutput o) {
       half4 tex = tex2D (_MainTex, IN.uv_MainTex);
       float4 c = tex * _Color;
-      o.Emission = c.rgb;
+      o.Emission = SrgbToLinear(c).rgb;
       o.Albedo = 0;
       if (c.a < _Cutoff) {
         discard;

--- a/Assets/Shaders/ColorPicker_hs_l.shader
+++ b/Assets/Shaders/ColorPicker_hs_l.shader
@@ -21,7 +21,8 @@ Properties {
 
 CGINCLUDE
     #include "Assets/Shaders/Include/ColorSpace.cginc"
-  #include "Assets/Shaders/Include/Hdr.cginc"
+    #include "Assets/Shaders/Include/ColorSpaceConvert.cginc"
+    #include "Assets/Shaders/Include/Hdr.cginc"
     float _Slider01;
     fixed4 _Color;
 
@@ -94,7 +95,7 @@ SubShader {
             float2 rang = xy_to_polar(i.texcoord);
             clip(1 - rang.x);
             float3 base_rgb = hue33_to_base_rgb(rang.y * 6);
-            return fixed4(sl_to_rgb(base_rgb, rang.x, _Slider01), 1) * _Color;
+            return SrgbToLinear(fixed4(sl_to_rgb(base_rgb, rang.x, _Slider01), 1) * _Color);
         }
 
         ENDCG

--- a/Assets/Shaders/ColorPicker_hs_logv.shader
+++ b/Assets/Shaders/ColorPicker_hs_logv.shader
@@ -20,7 +20,8 @@ Properties {
 }
 CGINCLUDE
     #include "Assets/Shaders/Include/ColorSpace.cginc"
-  #include "Assets/Shaders/Include/Hdr.cginc"
+    #include "Assets/Shaders/Include/ColorSpaceConvert.cginc"
+    #include "Assets/Shaders/Include/Hdr.cginc"
     float _Slider01;
     fixed4 _Color;
 
@@ -104,7 +105,7 @@ SubShader {
             float saturation = rang.x;
             // Convert from [0, 1] to [_LogVMin, _LogVMax]
             float hdr_value = hslogv_slider01_to_value(_Slider01, _LogVMin, _LogVMax);
-            return float4(sv_to_rgb(base_rgb, saturation, hdr_value), 1) * _Color;
+            return SrgbToLinear(float4(sv_to_rgb(base_rgb, saturation, hdr_value), 1) * _Color);
         }
 
         ENDCG

--- a/Assets/Shaders/ColorPicker_sl_h.shader
+++ b/Assets/Shaders/ColorPicker_sl_h.shader
@@ -21,7 +21,8 @@ Properties {
 
 CGINCLUDE
     #include "Assets/Shaders/Include/ColorSpace.cginc"
-  #include "Assets/Shaders/Include/Hdr.cginc"
+    #include "Assets/Shaders/Include/ColorSpaceConvert.cginc"
+    #include "Assets/Shaders/Include/Hdr.cginc"
     float _Slider01;
     fixed4 _Color;
 
@@ -91,7 +92,7 @@ SubShader {
         {
             float3 base_rgb = hue06_to_base_rgb(_Slider01 * 6);
             float2 uv = i.texcoord;
-            return cl_to_rgb(base_rgb, uv.x, uv.y) * _Color;
+            return SrgbToLinear(cl_to_rgb(base_rgb, uv.x, uv.y) * _Color);
         }
 
         ENDCG

--- a/Assets/Shaders/ColorPicker_sv_h.shader
+++ b/Assets/Shaders/ColorPicker_sv_h.shader
@@ -21,7 +21,8 @@ Properties {
 
 CGINCLUDE
     #include "Assets/Shaders/Include/ColorSpace.cginc"
-  #include "Assets/Shaders/Include/Hdr.cginc"
+    #include "Assets/Shaders/Include/ColorSpaceConvert.cginc"
+    #include "Assets/Shaders/Include/Hdr.cginc"
     float _Slider01;
     fixed4 _Color;
 
@@ -91,7 +92,7 @@ SubShader {
         {
             float3 base_rgb = hue06_to_base_rgb(_Slider01 * 6);
             float2 uv = i.texcoord;
-            return fixed4(sv_to_rgb(base_rgb, uv.x, uv.y), 1) * _Color;
+            return SrgbToLinear(fixed4(sv_to_rgb(base_rgb, uv.x, uv.y), 1) * _Color);
         }
 
         ENDCG

--- a/Assets/Shaders/Include/Brush.cginc
+++ b/Assets/Shaders/Include/Brush.cginc
@@ -20,6 +20,7 @@ uniform float4x4 xf_CS;
 uniform float4x4 xf_I_CS;
 uniform uint _BatchID;  // NOTOOLKIT
 #include "Ods.cginc"  // NOTOOLKIT
+#include "ColorSpaceConvert.cginc"
 
 // Unity only guarantees signed 2.8 for fixed4.
 // In practice, 2*exp(_EmissionGain * 10) = 180, so we need to use float4
@@ -101,35 +102,6 @@ float4 ParticleVertexToWorld(float4 vertex) {
   return vertex;
 }
 #endif
-
-//
-// For Toolkit support
-//
-
-float4 SrgbToLinear(float4 color) {
-  // Approximation http://chilliant.blogspot.com/2012/08/srgb-approximations-for-hlsl.html
-  float3 sRGB = color.rgb;
-  color.rgb = sRGB * (sRGB * (sRGB * 0.305306011 + 0.682171111) + 0.012522878);
-  return color;
-}
-
-float4 SrgbToLinear_Large(float4 color) {
-    float4 linearColor = SrgbToLinear(color);
-  color.r = color.r < 1.0 ? linearColor.r : color.r;
-  color.g = color.g < 1.0 ? linearColor.g : color.g;
-  color.b = color.b < 1.0 ? linearColor.b : color.b;
-  return color;
-}
-
-float4 LinearToSrgb(float4 color) {
-  // Approximation http://chilliant.blogspot.com/2012/08/srgb-approximations-for-hlsl.html
-  float3 linearColor = color.rgb;
-  float3 S1 = sqrt(linearColor);
-  float3 S2 = sqrt(S1);
-  float3 S3 = sqrt(S2);
-  color.rgb = 0.662002687 * S1 + 0.684122060 * S2 - 0.323583601 * S3 - 0.0225411470 * linearColor;
-  return color;
-}
 
 // TB mesh colors are sRGB. TBT mesh colors are linear.
 // TOOLKIT: float4 TbVertToSrgb(float4 color) { return LinearToSrgb(color); }

--- a/Assets/Shaders/Include/ColorSpaceConvert.cginc
+++ b/Assets/Shaders/Include/ColorSpaceConvert.cginc
@@ -1,0 +1,40 @@
+// Copyright 2020 The Tilt Brush Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Moved from Brush.cginc to be more helpful in other places.
+
+float4 SrgbToLinear(float4 color) {
+  // Approximation http://chilliant.blogspot.com/2012/08/srgb-approximations-for-hlsl.html
+  float3 sRGB = color.rgb;
+  color.rgb = sRGB * (sRGB * (sRGB * 0.305306011 + 0.682171111) + 0.012522878);
+  return color;
+}
+
+float4 SrgbToLinear_Large(float4 color) {
+    float4 linearColor = SrgbToLinear(color);
+  color.r = color.r < 1.0 ? linearColor.r : color.r;
+  color.g = color.g < 1.0 ? linearColor.g : color.g;
+  color.b = color.b < 1.0 ? linearColor.b : color.b;
+  return color;
+}
+
+float4 LinearToSrgb(float4 color) {
+  // Approximation http://chilliant.blogspot.com/2012/08/srgb-approximations-for-hlsl.html
+  float3 linearColor = color.rgb;
+  float3 S1 = sqrt(linearColor);
+  float3 S2 = sqrt(S1);
+  float3 S3 = sqrt(S2);
+  color.rgb = 0.662002687 * S1 + 0.684122060 * S2 - 0.323583601 * S3 - 0.0225411470 * linearColor;
+  return color;
+}

--- a/Assets/Shaders/Include/ColorSpaceConvert.cginc.meta
+++ b/Assets/Shaders/Include/ColorSpaceConvert.cginc.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0080a0f735091bc40938a5a458709e0f
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Performs a gamma to linear conversion of the palette on the color picker panel.
I've moved the color space changes from Brush.cginc to their own file to prevent cyclical redefinition.

Thanks to @ZandyXR for flagging the issue!