### PR TITLE
Change Steam beta branch names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -463,7 +463,7 @@ jobs:
           OPEN_BRUSH_APP_ID: 1634870
           OPEN_BRUSH_WINDOWS_DEPOT_ID: 1634871
           OPEN_BRUSH_EXECUTABLE: ${{ needs.configuration.outputs.basename}}.exe
-          CHANNEL: prerelease
+          CHANNEL: beta
       - name: Upload Experimental Build
         run: |
           pip install -U j2cli
@@ -478,7 +478,7 @@ jobs:
           OPEN_BRUSH_APP_ID: 1634870
           OPEN_BRUSH_WINDOWS_DEPOT_ID: 1634871
           OPEN_BRUSH_EXECUTABLE: ${{ needs.configuration.outputs.basename}}.exe
-          CHANNEL: prerelease-experimental
+          CHANNEL: beta-experimental
       - name: Save logs
         uses: actions/upload-artifact@v2
         if: ${{ failure() }}


### PR DESCRIPTION
Changes CI to upload to `beta` and `beta-experimental` branches instead of `prerelease`, to make things clearer to the end user.