### PR TITLE
Load sketches even with unknown stencil types

### DIFF
--- a/Assets/Scripts/Widgets/StencilWidget.cs
+++ b/Assets/Scripts/Widgets/StencilWidget.cs
@@ -319,8 +319,17 @@ namespace TiltBrush
 
             foreach (var state in guide.States)
             {
-                StencilWidget stencil = Instantiate(
+                StencilWidget stencil;
+                try
+                {
+                    stencil = Instantiate(
                     WidgetManager.m_Instance.GetStencilPrefab(stencilType));
+                }
+                catch (ArgumentException e)
+                {
+                    Debug.LogException(e);
+                    return;
+                }
 
                 stencil.m_SkipIntroAnim = true;
                 stencil.transform.parent = App.Instance.m_CanvasTransform;


### PR DESCRIPTION
When we added planar stencil we accidentally broke loading sketches that use it in older versions of TIlt Brush/Open Brush. This change prevents similar issues in future.