### PR TITLE
Update Android base package name

### DIFF
--- a/Assets/Editor/BuildTiltBrush.cs
+++ b/Assets/Editor/BuildTiltBrush.cs
@@ -48,7 +48,7 @@ static class BuildTiltBrush
     // The vendor name - used for naming android builds - shouldn't have spaces.
     public const string kVendorName = "Icosa";
     // The vendor name - used for the company name in builds and fbx output. Can have spaces.
-    public const string kDisplayVendorName = "Icosa Gallery";
+    public const string kDisplayVendorName = "Icosa Foundation";
 
     // Executable Base
     public const string kGuiBuildExecutableName = "OpenBrush";
@@ -59,7 +59,7 @@ static class BuildTiltBrush
     // OSX Executable
     public const string kGuiBuildOsxExecutableName = kGuiBuildExecutableName + ".app";
     // Android Application Identifier
-    public static string GuiBuildAndroidApplicationIdentifier => $"com.{kVendorName}.{kGuiBuildExecutableName}";
+    public static string GuiBuildAndroidApplicationIdentifier => $"foundation.{kVendorName}.{kGuiBuildExecutableName}".ToLower();
     // Android Executable
     public static string GuiBuildAndroidExecutableName => GuiBuildAndroidApplicationIdentifier + ".apk";
 
@@ -961,6 +961,10 @@ static class BuildTiltBrush
             m_company = PlayerSettings.companyName;
             string new_name = App.kAppDisplayName;
             string new_identifier = GuiBuildAndroidApplicationIdentifier;
+#if OCULUS_SUPPORTED
+            //Can't change Quest identifier
+            new_identifier = "com.Icosa.OpenBrush";
+#endif
             if (!String.IsNullOrEmpty(Description))
             {
                 new_name += " (" + Description + ")";

--- a/Assets/Plugins/Android/AndroidManifest.xml
+++ b/Assets/Plugins/Android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    android:installLocation="auto" package="com.Icosa.OpenBrush"
+    android:installLocation="auto" package="foundation.icosa.openbrush"
     xmlns:tools="http://schemas.android.com/tools">
     <application
         android:allowBackup="false"

--- a/Assets/Plugins/Android/AndroidManifest.xml
+++ b/Assets/Plugins/Android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    android:installLocation="auto" package="foundation.icosa.openbrush"
+    android:installLocation="auto"
     xmlns:tools="http://schemas.android.com/tools">
     <application
         android:allowBackup="false"

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -12,7 +12,7 @@ PlayerSettings:
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60
-  companyName: Icosa
+  companyName: Icosa Foundation
   productName: Open Brush
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
@@ -160,7 +160,7 @@ PlayerSettings:
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
     Android: com.icosa.openbrush
-    Standalone: com.icosa.openbrush
+    Standalone: foundation.icosa.openbrush
     Tizen: com.yourcompany.yourproduct
     WebGL: com.yourcompany.yourproduct
     Windows Store Apps: com.yourcompany.yourproduct


### PR DESCRIPTION
Updates apk package name to reflect our correct domain as we publish to more platforms.

Override specifically for Oculus platform as we're already published there so we're locked in.