### PR TITLE
Custom google api core with Unity's Newtonsoft JSON

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -21,7 +21,7 @@
     "com.unity.xr.openxr": "1.5.3",
     "org.nuget.google.apis": "1.57.0",
     "org.nuget.google.apis.auth": "1.57.0",
-    "org.nuget.google.apis.core": "1.57.0",
+    "org.nuget.google.apis.core": "https://github.com/icosa-mirror/org.nuget.google.apis.core.git#unity-newtonsoft",
     "org.nuget.sharpziplib": "1.3.1",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -89,6 +89,13 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.nuget.newtonsoft-json": {
+      "version": "3.0.2",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.performance.profile-analyzer": {
       "version": "1.1.1",
       "depth": 0,
@@ -156,7 +163,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.xr.legacyinputhelpers": {
-      "version": "2.1.10",
+      "version": "2.1.9",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -218,20 +225,13 @@
       "url": "https://unitynuget-registry.azurewebsites.net"
     },
     "org.nuget.google.apis.core": {
-      "version": "1.57.0",
+      "version": "https://github.com/icosa-mirror/org.nuget.google.apis.core.git#unity-newtonsoft",
       "depth": 0,
-      "source": "registry",
+      "source": "git",
       "dependencies": {
-        "org.nuget.newtonsoft.json": "13.0.1"
+        "com.unity.nuget.newtonsoft-json": "2.0.2"
       },
-      "url": "https://unitynuget-registry.azurewebsites.net"
-    },
-    "org.nuget.newtonsoft.json": {
-      "version": "13.0.1",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://unitynuget-registry.azurewebsites.net"
+      "hash": "87f1383eaf64980de11fa5d7cbc0e1c09bf4904d"
     },
     "org.nuget.sharpziplib": {
       "version": "1.3.1",


### PR DESCRIPTION
Switches back to using Unity's version of Newtonsoft JSON by using a modified dependency of Google API core hosted on our mirror repo.

This gives us more flexibility when it comes to adding other packages, like glTF importers and localization.