### PR TITLE
Unknown brush breaks loading

### DIFF
--- a/Assets/Scripts/Stroke.cs
+++ b/Assets/Scripts/Stroke.cs
@@ -88,7 +88,9 @@ namespace TiltBrush
                 }
                 else if (m_Type == Type.BrushStroke)
                 {
-                    return m_Object.GetComponent<BaseBrushScript>().Canvas;
+                    // Null checking is needed because sketches that fail to load
+                    // can create invalid strokes that with no script.
+                    return m_Object?.GetComponent<BaseBrushScript>()?.Canvas;
                 }
                 else
                 {


### PR DESCRIPTION
After loading a sketch with a missing brush, any attempt to load a new sketch fails unless you restart.