### PR TITLE
Fix build warnings that only showed up when releasing a version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -399,7 +399,7 @@ jobs:
           fetch-depth: 0
           lfs: true  # We don't use LFS, but it adds no time, and leave it here in case we do at some point later
       - name: Setup steamcmd
-        uses: CyberAndrii/setup-steamcmd@v1.1.1
+        uses: CyberAndrii/setup-steamcmd@v1.1.5
       - name: Restore steam login config
         run: |
           mkdir -p /home/runner/Steam/config

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -375,7 +375,7 @@ jobs:
           rm -rf OpenBrush_Rift_$VERSION
           rm -rf OpenBrush_Rift_Experimental_$VERSION
       - name: Publish
-        uses: softprops/action-gh-release@v1
+        uses: koplo199/action-gh-release@1.0  # softprops/action-gh-release@v1 didn't update to node16 and fix set-output.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
* Fix setup-steamcmd by upgrading the v1.1.5
* Replace softprops/action-gh-release with koplo199's fork, because these two issues have gone unaddressed:
https://github.com/softprops/action-gh-release/issues/249
https://github.com/softprops/action-gh-release/issues/265
(both have duplicates, but these are the oldest reported issue)