### PR TITLE
Mark config dirty on build

### DIFF
--- a/Assets/Editor/BuildTiltBrush.cs
+++ b/Assets/Editor/BuildTiltBrush.cs
@@ -1418,6 +1418,7 @@ static class BuildTiltBrush
             config.m_BuildStamp = stamp;
             //config.OnValidate(xrSdk, TargetToGroup(target));
             config.DoBuildTimeConfiguration(target);
+            EditorUtility.SetDirty(config);
 
             if (GuiSelectedBuildTarget == BuildTarget.Android)
             {


### PR DESCRIPTION
Fixes an issue where we were setting mobile config on android builds, but it wasn't properly added to the build as the config file wasn't marked as changed. This caused a number of 'issues' that didn't have much real-world performance consequences, but produced errors such as
- Using the full version of the intro sketch, instead of the optimised one
- Video listed on the multi-cam tool
- no memory limit panel appearing