### PR TITLE
Change graphics backend per platform

### DIFF
--- a/Assets/Editor/BuildTiltBrush.cs
+++ b/Assets/Editor/BuildTiltBrush.cs
@@ -1163,7 +1163,7 @@ static class BuildTiltBrush
                     targetGraphicsApisRequired = new UnityEngine.Rendering.GraphicsDeviceType[] { UnityEngine.Rendering.GraphicsDeviceType.OpenGLES3 };
                     break;
                 default:
-                    targetGraphicsApisRequired = new UnityEngine.Rendering.GraphicsDeviceType[] {};
+                    targetGraphicsApisRequired = new UnityEngine.Rendering.GraphicsDeviceType[] { };
                     break;
             }
 

--- a/Assets/Editor/BuildTiltBrush.cs
+++ b/Assets/Editor/BuildTiltBrush.cs
@@ -1145,6 +1145,37 @@ static class BuildTiltBrush
         }
     }
 
+    class TempSetGraphicsApis : IDisposable
+    {
+        UnityEngine.Rendering.GraphicsDeviceType[] m_graphicsApis;
+
+        BuildTarget m_Target;
+
+        public TempSetGraphicsApis(TiltBuildOptions tiltOptions)
+        {
+            m_Target = tiltOptions.Target;
+            m_graphicsApis = PlayerSettings.GetGraphicsAPIs(tiltOptions.Target);
+            UnityEngine.Rendering.GraphicsDeviceType[] targetGraphicsApisRequired;
+
+            switch (tiltOptions.XrSdk)
+            {
+                case XrSdkMode.Wave:
+                    targetGraphicsApisRequired = new UnityEngine.Rendering.GraphicsDeviceType[] { UnityEngine.Rendering.GraphicsDeviceType.OpenGLES3 };
+                    break;
+                default:
+                    targetGraphicsApisRequired = new UnityEngine.Rendering.GraphicsDeviceType[] {};
+                    break;
+            }
+
+            PlayerSettings.SetGraphicsAPIs(m_Target, targetGraphicsApisRequired);
+        }
+
+        public void Dispose()
+        {
+            PlayerSettings.SetGraphicsAPIs(m_Target, m_graphicsApis);
+        }
+    }
+
     class RestoreFileContents : IDisposable
     {
         string[] m_files;
@@ -1402,6 +1433,7 @@ static class BuildTiltBrush
             tiltOptions.AutoProfile ? "AUTOPROFILE_ENABLED" : null))
         using (var unused4 = new TempHookUpSingletons())
         using (var unused5 = new TempSetScriptingBackend(target, tiltOptions.Il2Cpp))
+        using (var unused14 = new TempSetGraphicsApis(tiltOptions))
         using (var unused6 = new TempSetBundleVersion(App.Config.m_VersionNumber, stamp))
         using (var unused10 = new TempSetAppNames(target == BuildTarget.Android, tiltOptions.Description))
         using (var unused7 = new TempSetXrPlugin(tiltOptions))

--- a/Assets/Editor/BuildTiltBrush.cs
+++ b/Assets/Editor/BuildTiltBrush.cs
@@ -1163,7 +1163,7 @@ static class BuildTiltBrush
                     targetGraphicsApisRequired = new UnityEngine.Rendering.GraphicsDeviceType[] { UnityEngine.Rendering.GraphicsDeviceType.OpenGLES3 };
                     break;
                 default:
-                    targetGraphicsApisRequired = new UnityEngine.Rendering.GraphicsDeviceType[] { };
+                    targetGraphicsApisRequired = m_graphicsApis;
                     break;
             }
 


### PR DESCRIPTION
This is pre-work for wave SDK, which currently requires GLES 3.0 while we use Vulkan right now. This may also help our Pico builds.