### PR TITLE
Set ASTC to default tex format for android

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,23 +141,23 @@ jobs:
           - name: Android OpenXR
             targetPlatform: Android
             vrsdk: OpenXR
-            extraoptions: -setDefaultPlatformTextureFormat astc -btb-il2cpp
+            extraoptions: -btb-il2cpp
           - name: Oculus Quest
             targetPlatform: Android
             vrsdk: Oculus
-            extraoptions: -setDefaultPlatformTextureFormat astc -btb-il2cpp
+            extraoptions: -btb-il2cpp
           - name: Oculus Quest Experimental
             targetPlatform: Android
             vrsdk: Oculus
-            extraoptions: -setDefaultPlatformTextureFormat astc -btb-il2cpp -btb-experimental
+            extraoptions: -btb-il2cpp -btb-experimental
           - name: Android Pico
             targetPlatform: Android
             vrsdk: Pico
-            extraoptions: -setDefaultPlatformTextureFormat astc -btb-il2cpp
+            extraoptions: -btb-il2cpp
           - name: Android Pico Experimental
             targetPlatform: Android
             vrsdk: Pico
-            extraoptions: -setDefaultPlatformTextureFormat astc -btb-il2cpp -btb-experimental
+            extraoptions: -btb-il2cpp -btb-experimental
 
 
     steps:

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -505,7 +505,9 @@ PlayerSettings:
     m_EncodingQuality: 1
   m_BuildTargetGroupLightmapSettings: []
   m_BuildTargetNormalMapEncoding: []
-  m_BuildTargetDefaultTextureCompressionFormat: []
+  m_BuildTargetDefaultTextureCompressionFormat:
+  - m_BuildTarget: Android
+    m_Format: 3
   playModeTestRunnerEnabled: 0
   runPlayModeTestAsEditModeTest: 0
   actionOnDotNetUnhandledException: 1


### PR DESCRIPTION
Before, we passed through ASTC as a build option for all android builds, but we can just set it as default instead