### PR TITLE
Fix dotnet format in CI (and possibly locally)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,8 +10,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-python@v4.3.0
+      - uses: actions/setup-dotnet@v3.0.3
         with:
-          dotnet-version: '6.0.100'
-      - uses: pre-commit/action@v2.0.0
+          dotnet-version: '7.0.x'
+      - name: "HACK: manually install dotnet-format into pre-commit's cache"
+        run: |
+          pip install pre-commit
+          set +e
+          echo "Ignore the error below:"
+          pre-commit run dotnet-format # This will fail, so ignore it, but we need it to create the "random" directory for the dotnet-format
+          echo "Don't ignore any error that come after this point"
+          set -e
+          PRE_COMMIT_PATHS="$(echo 'SELECT path FROM repos WHERE repo == "https://github.com/dotnet/format";' | sqlite3 ~/.cache/pre-commit/db.db)"
+          for path in $PRE_COMMIT_PATHS
+          do
+              PRE_COMMIT_PATH="${path}/dotnetenv-default/bin"
+              dotnet tool install dotnet-format --version "7.*" --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json --tool-path $PRE_COMMIT_PATH
+              echo '{"additional_dependencies": []}' > $PRE_COMMIT_PATH/../.install_state_v1
+          done
+      - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,8 +24,9 @@ repos:
         language_version: python3
         args:
           - --load-plugins=pylint.extensions.redefined_variable_type,pylint.extensions.bad_builtin
+          - --disable=import-error
   - repo: https://github.com/dotnet/format
-    rev: "aec7996c51c76644de6014bbcce9264d402a8db0"
+    rev: "a2c1431dabf2229052cf598f86f31bc3eac5bc7b"  # Main as of 2022-12-05
     hooks:
       - id: dotnet-format
         exclude: ^(Assets/ThirdParty)|(Packages/)

--- a/Assets/Scripts/AudioManager.cs
+++ b/Assets/Scripts/AudioManager.cs
@@ -80,13 +80,13 @@ namespace TiltBrush
         private int m_ActiveGameMusicIndex;
 
         [SerializeField] private AudioClip m_IntroTransitionSound;
-        [Range(0.0f, 24.0f)] [SerializeField] private float m_IntroTransitionGain = 0.0f;
+        [Range(0.0f, 24.0f)][SerializeField] private float m_IntroTransitionGain = 0.0f;
         [SerializeField] private AudioClip m_ActivatePanelSound;
         [SerializeField] private AudioClip m_DeactivatePanelSound;
         [SerializeField] private AudioClip m_PopUpSound;
-        [Range(0.0f, 24.0f)] [SerializeField] private float m_PopUpGain = 0.0f;
+        [Range(0.0f, 24.0f)][SerializeField] private float m_PopUpGain = 0.0f;
         [SerializeField] private float m_PanelActivationVolume = 0.5f;
-        [Range(0.0f, 24.0f)] [SerializeField] private float m_PanelActivationGain = 0.0f;
+        [Range(0.0f, 24.0f)][SerializeField] private float m_PanelActivationGain = 0.0f;
         public float m_PanelActivateMinTriggerTime;
         private float m_PanelActivateTimestamp;
 
@@ -95,7 +95,7 @@ namespace TiltBrush
         private int m_ItemHoverSoundIndex;
 
         [SerializeField] private AudioClip[] m_ItemSelectSounds;
-        [Range(0.0f, 24.0f)] [SerializeField] private float m_ItemSelectGain = 0.0f;
+        [Range(0.0f, 24.0f)][SerializeField] private float m_ItemSelectGain = 0.0f;
 
         [SerializeField] private AudioClip m_ItemDisabledSound;
 
@@ -103,7 +103,7 @@ namespace TiltBrush
         [SerializeField] private AudioClip[] m_RedoSounds;
 
         [SerializeField] private AudioClip m_InitWorldGrabSound;
-        [Range(0.0f, 24.0f)] [SerializeField] private float m_InitWorldGrabGain = 0.0f;
+        [Range(0.0f, 24.0f)][SerializeField] private float m_InitWorldGrabGain = 0.0f;
         [SerializeField] private float m_InitWorldGrabMinTriggerTime;
         private float m_InitWorldGrabTimestamp;
         [SerializeField] private AudioClip m_WorldGrabLoop;
@@ -112,26 +112,26 @@ namespace TiltBrush
         public float m_WorldGrabLoopSmoothSpeed = 50f;
 
         [SerializeField] private AudioClip m_WidgetShowSound;
-        [Range(0.0f, 24.0f)] [SerializeField] private float m_WidgetShowGain = 0.0f;
+        [Range(0.0f, 24.0f)][SerializeField] private float m_WidgetShowGain = 0.0f;
         [SerializeField] private AudioClip m_WidgetHideSound;
-        [Range(0.0f, 24.0f)] [SerializeField] private float m_WidgetHideGain = 0.0f;
+        [Range(0.0f, 24.0f)][SerializeField] private float m_WidgetHideGain = 0.0f;
         [SerializeField] private float m_WidgetShowHideMinTriggerTime = 0.1f;
         private float m_WidgetShowHideTimestamp;
 
         [SerializeField] private AudioClip m_PanelFlipSound;
         [SerializeField] private float m_PanelFlipVolume = 1.0f;
-        [Range(0.0f, 24.0f)] [SerializeField] private float m_PanelFlipGain = 0.0f;
+        [Range(0.0f, 24.0f)][SerializeField] private float m_PanelFlipGain = 0.0f;
 
         [SerializeField] private AudioClip m_MagicControllerSound;
-        [Range(0.0f, 24.0f)] [SerializeField] private float m_MagicControllerGain = 0.0f;
+        [Range(0.0f, 24.0f)][SerializeField] private float m_MagicControllerGain = 0.0f;
         [SerializeField] private AudioClip m_TeleportSound;
-        [Range(0.0f, 1.0f)] [SerializeField] private float m_TeleportVolume = 1.0f;
+        [Range(0.0f, 1.0f)][SerializeField] private float m_TeleportVolume = 1.0f;
         [SerializeField] private AudioClip m_DuplicateSound;
-        [Range(0.0f, 24.0f)] [SerializeField] private float m_DuplicateGain = 0.0f;
+        [Range(0.0f, 24.0f)][SerializeField] private float m_DuplicateGain = 0.0f;
         [SerializeField] private AudioClip m_MirrorSound;
         [SerializeField] private AudioClip m_MirrorReflectionSound;
         [SerializeField] private AudioClip m_ScreenshotSound;
-        [Range(0.0f, 1.0f)] [SerializeField] private float m_ScreenshotVolume = 1.0f;
+        [Range(0.0f, 1.0f)][SerializeField] private float m_ScreenshotVolume = 1.0f;
         [SerializeField] private AudioClip m_TrashSound;
         [SerializeField] private AudioClip m_TrashSoftSound;
         // TODO: Should this sound be used or removed?
@@ -140,30 +140,30 @@ namespace TiltBrush
         private AudioClip m_CountdownSound;
         [SerializeField] private AudioClip m_HintAnimateSound;
         [SerializeField] private AudioClip m_SliderSound;
-        [Range(0.0f, 1.0f)] [SerializeField] private float m_SliderVolume = 1.0f;
+        [Range(0.0f, 1.0f)][SerializeField] private float m_SliderVolume = 1.0f;
         [SerializeField] private AudioClip m_SketchLoadedSound;
-        [Range(0.0f, 24.0f)] [SerializeField] private float m_SketchLoadedGain = 0.0f;
+        [Range(0.0f, 24.0f)][SerializeField] private float m_SketchLoadedGain = 0.0f;
         [SerializeField] private AudioClip m_SketchUploadCompleteSound;
-        [Range(0.0f, 24.0f)] [SerializeField] private float m_SketchUploadCompleteGain = 0.0f;
+        [Range(0.0f, 24.0f)][SerializeField] private float m_SketchUploadCompleteGain = 0.0f;
         [SerializeField] private AudioClip m_SketchUploadCanceledSound;
         [SerializeField] private AudioClip m_ControllerSwapSound;
         [SerializeField] private AudioClip m_SaveSketchSound;
-        [Range(0.0f, 24.0f)] [SerializeField] private float m_SaveSketchGain = 0.0f;
+        [Range(0.0f, 24.0f)][SerializeField] private float m_SaveSketchGain = 0.0f;
         [SerializeField] private AudioClip m_PinCushionOpenSound;
-        [Range(0.0f, 1.0f)] [SerializeField] private float m_PinCushionOpenVolume = 1.0f;
+        [Range(0.0f, 1.0f)][SerializeField] private float m_PinCushionOpenVolume = 1.0f;
         [SerializeField] private AudioClip m_PinCushionCloseSound;
-        [Range(0.0f, 1.0f)] [SerializeField] private float m_PinCushionCloseVolume = 1.0f;
+        [Range(0.0f, 1.0f)][SerializeField] private float m_PinCushionCloseVolume = 1.0f;
         [SerializeField] private AudioClip m_PinCushionHoverSound;
-        [Range(0.0f, 1.0f)] [SerializeField] private float m_PinCushionHoverVolume = 1.0f;
+        [Range(0.0f, 1.0f)][SerializeField] private float m_PinCushionHoverVolume = 1.0f;
         [SerializeField] private AudioClip m_DropperIntersectionSound;
         [SerializeField] private AudioClip m_DropperPickSound;
-        [Range(0.0f, 24.0f)] [SerializeField] private float m_DropperPickGain = 0.0f;
+        [Range(0.0f, 24.0f)][SerializeField] private float m_DropperPickGain = 0.0f;
         [SerializeField] private AudioClip m_BasicToAdvancedModeSound;
-        [Range(0.0f, 24.0f)] [SerializeField] private float m_BasicToAdvancedModeGain = 0.0f;
+        [Range(0.0f, 24.0f)][SerializeField] private float m_BasicToAdvancedModeGain = 0.0f;
         [SerializeField] private AudioClip m_AdvancedToBasicModeSound;
-        [Range(0.0f, 24.0f)] [SerializeField] private float m_AdvancedToBasicModeGain = 0.0f;
+        [Range(0.0f, 24.0f)][SerializeField] private float m_AdvancedToBasicModeGain = 0.0f;
         [SerializeField] private AudioClip m_TransformResetSound;
-        [Range(0.0f, 1.0f)] [SerializeField] private float m_TransformResetVolume = 1.0f;
+        [Range(0.0f, 1.0f)][SerializeField] private float m_TransformResetVolume = 1.0f;
         [SerializeField] private float m_HintAnimateMinTriggerTime;
         private float m_HintAnimateTimestamp;
 
@@ -173,12 +173,12 @@ namespace TiltBrush
         [SerializeField] private float m_PanelPaneMoveMinTriggerTime = .2f;
 
         [SerializeField] private AudioClip m_UploadLoop;
-        [Range(0.0f, 24.0f)] [SerializeField] private float m_UploadLoopGain = 0.0f;
+        [Range(0.0f, 24.0f)][SerializeField] private float m_UploadLoopGain = 0.0f;
         [SerializeField] private AudioClip m_UploadLoopQuiet;
-        [Range(0.0f, 24.0f)] [SerializeField] private float m_UploadLoopQuietGain = 0.0f;
+        [Range(0.0f, 24.0f)][SerializeField] private float m_UploadLoopQuietGain = 0.0f;
         [SerializeField] float m_UploadLoopFadeDownDuration = 3f;
         [SerializeField] private AudioClip m_SelectionHighlightLoop;
-        [Range(0.0f, 1.0f)] [SerializeField] private float m_SelectionHighlightVolume = 1.0f;
+        [Range(0.0f, 1.0f)][SerializeField] private float m_SelectionHighlightVolume = 1.0f;
         [SerializeField] private float m_SelectionHighlightFadeDownSpeed = 0.2f;
 
         public enum PinSoundType

--- a/Assets/Scripts/GUI/FloatPropertySlider.cs
+++ b/Assets/Scripts/GUI/FloatPropertySlider.cs
@@ -20,7 +20,7 @@ namespace TiltBrush
     {
 
         [SerializeField] private SerializedPropertyReferenceFloat m_Property;
-        [Vec2AsRange] [SerializeField] private Vector2 m_Range = Vector2.up;
+        [Vec2AsRange][SerializeField] private Vector2 m_Range = Vector2.up;
         [Tooltip("Values < 1 will bias the low end - Values > 1 will bias the high end.")]
         [SerializeField] private float m_PowerCurve = 1;
 

--- a/Assets/Scripts/GUI/GpuTextRender.cs
+++ b/Assets/Scripts/GUI/GpuTextRender.cs
@@ -26,7 +26,7 @@ namespace TiltBrush
         [SerializeField] private Material m_Material;
         [SerializeField] private int m_Width;
         [SerializeField] private int m_Height;
-        [SerializeField] [Multiline(16)] private string m_Text;
+        [SerializeField][Multiline(16)] private string m_Text;
 
         private RenderTexture m_TargetTexture;
         private Texture2D m_SourceTexture;

--- a/Assets/Scripts/Input/BaseControllerBehavior.cs
+++ b/Assets/Scripts/Input/BaseControllerBehavior.cs
@@ -35,7 +35,7 @@ namespace TiltBrush
         // -------------------------------------------------------------------------------------------- //
         [SerializeField] private InputManager.ControllerName m_ControllerName;
         [SerializeField] private ControllerGeometry m_ControllerGeometryPrefab;
-        [FormerlySerializedAs("m_Offset")] [SerializeField] private Vector3 m_GeometryOffset;
+        [FormerlySerializedAs("m_Offset")][SerializeField] private Vector3 m_GeometryOffset;
         [FormerlySerializedAs("m_Rotation")]
         [SerializeField]
         private Quaternion m_GeometryRotation = Quaternion.identity;


### PR DESCRIPTION
Fix dotnet-format in pre-commit

.NET has moved to 7.x, and with it, pre-commit no longer installs
dotnet-format properly. It gives this error:

    [INFO] Initializing environment for https://github.com/dotnet/format.
    [INFO] Installing environment for https://github.com/dotnet/format.
    [INFO] Once installed this environment will be reused.
    [INFO] This may take a few minutes...
    An unexpected error has occurred: CalledProcessError: command: ('/usr/local/bin/dotnet', 'tool', 'install', '--tool-path', '/Users/FOO/.cache/pre-commit/repoXXXXXXXX/dotnetenv-default/bin', '--add-source', 'pre-commit-build', 'dotnet-format')
    return code: 1
    expected return code: 0
    stdout:
        /var/folders/0b/mq_jkw6n6x75xr18vy44lmb40000gn/T/ab063401-9d0d-4610-a73d-6db1b84c23b8/restore.csproj : error NU1100: Unable to resolve 'dotnet-format (>= 0.0.0)' for 'net7.0'. PackageSourceMapping is enabled, the following source(s) were not considered: /Users/FOO/.cache/pre-commit/repoXXXXXXXX/pre-commit-build, dotnet-eng, dotnet-libraries, dotnet-public, dotnet-tools, dotnet7.
        /var/folders/0b/mq_jkw6n6x75xr18vy44lmb40000gn/T/ab063401-9d0d-4610-a73d-6db1b84c23b8/restore.csproj : error NU1100: Unable to resolve 'dotnet-format (>= 0.0.0)' for 'net7.0/any'. PackageSourceMapping is enabled, the following source(s) were not considered: /Users/FOO/.cache/pre-commit/repoXXXXXXXX/pre-commit-build, dotnet-eng, dotnet-libraries, dotnet-public, dotnet-tools, dotnet7.

    stderr:
        The tool package could not be restored.
        Tool 'dotnet-format' failed to install. This failure may have been caused by:

        * You are attempting to install a preview release and did not use the --version option to specify the version.
        * A package by this name was found, but it was not a .NET tool.
        * The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
        * You mistyped the name of the tool.

        For more reasons, including package naming enforcement, visit https://aka.ms/failure-installing-tool

By resurrecting the hack from #166, we can install dotnet format
directly, manually.

I don't know what causes this, but at least it's documented for the next
time!