### PR TITLE
Build tweaks and improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "mikeage"
+    assignees:
+      - "mikeage"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -386,13 +386,13 @@ jobs:
           path: build_oculus_quest_experimental
 
       - name: Download Build Artifacts (Pico)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: Android Pico
           path: build_android_pico
 
       - name: Download Build Artifacts (Pico Experimental)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: Android Pico Experimental
           path: build_android_pico_experimental

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,22 +176,24 @@ jobs:
         if: matrix.targetPlatform == 'Android'
         run: |
           echo "Initial free space"
-          df -h
-          docker rmi $(docker image ls -aq)
-          #echo "Listing 100 largest packages"
-          #dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -rn | head -n 100
-          df -h
-          echo "Removing large packages"
+          df -h /
+          echo "Removing all pre-loaded docker images"
+          docker rmi $(docker image ls -aq)  # Removes ~4GB
+          df -h /
+          # echo "Listing 100 largest packages"
+          # dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -rn | head -n 100
+          echo "Removing unneeded large packages"
           sudo apt-get update
-          sudo apt-get remove -y '^ghc-.*' '^dotnet-.*' azure-cli google-cloud-sdk 'adoptopenjdk-.*-hotspot' google-chrome-stable firefox 'php.*'
+          sudo apt-get remove -y '^ghc-.*' '^dotnet-.*' hhvm azure-cli google-cloud-sdk powershell google-chrome-stable firefox microsoft-edge-stable 'php.*' 'mongodb-*' 'mysql-*' 'mariadb-*' 'adoptopenjdk-.*-hotspot' 'temurin-*' 'openjdk-*' default-jre-headless  # Removes ~7.5 GB
           sudo apt-get autoremove -y
           sudo apt-get clean
-          df -h
+          df -h /
           echo "Removing remaining large directories"
-          rm -rf /usr/share/dotnet/
-          rm -rf "$AGENT_TOOLSDIRECTORY"
+          rm -rf /usr/share/dotnet/  # Removes ~1GB
+          df -h /
+          rm -rf "$AGENT_TOOLSDIRECTORY"  # Removes ~7GB
           echo "Disk space after cleanup"
-          df -h
+          df -h /
 
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -34,7 +34,10 @@ jobs:
           for path in $PRE_COMMIT_PATHS
           do
               PRE_COMMIT_PATH="${path}/dotnetenv-default/bin"
-              dotnet tool install dotnet-format --version "7.*" --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json --tool-path $PRE_COMMIT_PATH
+              if [ ! -f ${PRE_COMMIT_PATH}/dotnet-format ]
+              then
+                  dotnet tool install dotnet-format --version "7.*" --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json --tool-path $PRE_COMMIT_PATH
+              fi
               echo '{"additional_dependencies": []}' > $PRE_COMMIT_PATH/../.install_state_v1
           done
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,6 +4,9 @@ name: pre-commit
 
 on:  # yamllint disable-line rule:truthy
   pull_request:
+  push:
+    branches:
+      - main  # We never expect this to fail, since it must have passed on the pull request, but this will let us create a cache on main that other PRs can use, speeding up the process
 
 jobs:
   pre-commit:
@@ -14,6 +17,11 @@ jobs:
       - uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: '7.0.x'
+      - name: Cache pre-commit directories  # This is also built into the action, but we want to create our own cache (which they can load) because of the hack below. If we remove it, we can remove this cache as well
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: "HACK: manually install dotnet-format into pre-commit's cache"
         run: |
           pip install pre-commit


### PR DESCRIPTION
* pre-commit time reduced from ~2:10 to ~1:00 on subsequent runs on a branch by using a manual cache
* Same improvement applied to the first run, by (creating and) using the cache from main
* Free space increased from ~48GB to ~51GB for Android builds (initial free space without this step is ~31GB, which is not enough). Other platforms don't need the extra space, so we skip this step (takes ~2:20)
* Three warnings removed from older actions
* Enable dependabot for github actions