### PR TITLE
Disable the image cleanup for Android

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,7 @@ jobs:
     steps:
       - name: Free extra space
         # This takes several minutes, so we only do it where required
-        if: matrix.targetPlatform == 'Android'
+        if: false  # We needed this to build for Android with the Ubuntu 20.04 image, which started with 29GB free. The 22.04 starts with 37GB free, and this is enough.
         run: |
           echo "Initial free space"
           df -h


### PR DESCRIPTION
We used to need this, but we no longer do (tested even with a clean build without any caches). Removing it saves ~2:30 on Android builds (negligible on a clean build, but about 10% of a cache build).