### PR TITLE
Improve Quest config settings

### DIFF
--- a/Assets/Scripts/Rendering/RenderWrapper.cs
+++ b/Assets/Scripts/Rendering/RenderWrapper.cs
@@ -233,23 +233,23 @@ namespace TiltBrush
 #if UNITY_ANDROID
     // TODO:Mike - setting MSAA seems to crash quest when in Vulkan
     
-    // int msaa = QualityControls.m_Instance.MSAALevel;
-    // // MSAA disabled in QualityControls = 0, but render texture wants 1.
-    // if (msaa == 0) {
-    //   msaa = 1;
-    // }
-    // if (msaa != 1 && msaa != 2 && msaa != 4 && msaa != 8) {
-    //   UnityEngine.Debug.LogWarningFormat("Invalid MSAA {0} != [1,2,4,8]", msaa);
-    //   msaa = 1;
-    // }
+    int msaa = QualityControls.m_Instance.MSAALevel;
+    // MSAA disabled in QualityControls = 0, but render texture wants 1.
+    if (msaa == 0) {
+      msaa = 1;
+    }
+    if (msaa != 1 && msaa != 2 && msaa != 4 && msaa != 8) {
+      UnityEngine.Debug.LogWarningFormat("Invalid MSAA {0} != [1,2,4,8]", msaa);
+      msaa = 1;
+    }
 
-    // if (msaa != QualitySettings.antiAliasing) {
-    //   QualitySettings.antiAliasing = msaa;
-    // }
-    // GetComponent<Camera>().allowMSAA = msaa > 1;
+    if (msaa != QualitySettings.antiAliasing) {
+      QualitySettings.antiAliasing = msaa;
+    }
+    GetComponent<Camera>().allowMSAA = msaa > 1;
 
-    // // Use a single camera on Android.
-    // return;
+    // Use a single camera on Android.
+    return;
 #else
 
             Camera srcCam = GetComponent<Camera>();

--- a/Assets/XR/Settings/Oculus Settings.asset
+++ b/Assets/XR/Settings/Oculus Settings.asset
@@ -15,17 +15,17 @@ MonoBehaviour:
   m_StereoRenderingModeDesktop: 0
   m_StereoRenderingModeAndroid: 0
   SharedDepthBuffer: 1
-  DepthSubmission: 0
+  DepthSubmission: 1
   DashSupport: 1
   LowOverheadMode: 0
   OptimizeBufferDiscards: 1
-  PhaseSync: 0
-  SymmetricProjection: 1
+  PhaseSync: 1
+  SymmetricProjection: 0
   SubsampledLayout: 0
-  FoveatedRenderingMethod: 1
+  FoveatedRenderingMethod: 0
   LateLatching: 0
   LateLatchingDebug: 0
-  EnableTrackingOriginStageMode: 0
+  EnableTrackingOriginStageMode: 1
   SpaceWarp: 0
   TargetQuest: 1
   TargetQuest2: 1

--- a/Assets/XR/Settings/Oculus Settings.asset
+++ b/Assets/XR/Settings/Oculus Settings.asset
@@ -25,7 +25,7 @@ MonoBehaviour:
   FoveatedRenderingMethod: 0
   LateLatching: 0
   LateLatchingDebug: 0
-  EnableTrackingOriginStageMode: 1
+  EnableTrackingOriginStageMode: 0
   SpaceWarp: 0
   TargetQuest: 1
   TargetQuest2: 1


### PR DESCRIPTION
Makes changes to the enabled features on Quest based on the documentation provided for the plugin: https://docs.unity3d.com/Packages/com.unity.xr.oculus@3.2/manual/index.html

This appeared to allow us to re-enable MSAA for android! Will need to test all platforms though.