### PR TITLE
Remove upload of experimental build(s) and pre-release channel for Steam. Just keep beta channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -461,7 +461,7 @@ jobs:
         with:
           name: Windows OpenXR
           path: build_windows_openxr
-      - name: Upload Regular Build
+      - name: Upload Build
         run: |
           pip install -U j2cli
           j2 Support/steam/app.vdf.j2 > build_windows_openxr/app.vdf
@@ -476,56 +476,6 @@ jobs:
           OPEN_BRUSH_WINDOWS_DEPOT_ID: 1634871
           OPEN_BRUSH_EXECUTABLE: ${{ needs.configuration.outputs.basename}}.exe
           CHANNEL: beta
-      # Temporary - upload to old prerelease channels
-      # TODO: remove at 2.0
-      - name: Upload Legacy Regular Build
-        run: |
-          pip install -U j2cli
-          j2 Support/steam/app.vdf.j2 > build_windows_openxr/app.vdf
-          j2 Support/steam/main_depot.vdf.j2 > build_windows_openxr/main_depot.vdf
-          j2 Support/steam/installscript_win.vdf.j2 > build_windows_openxr/installscript_win.vdf
-          steamcmd +login $STEAM_USERNAME $STEAM_PASSWORD +run_app_build $(pwd)/build_windows_openxr/app.vdf +quit
-        env:
-          STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
-          STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }}
-          VERSION: ${{ needs.configuration.outputs.version }}
-          OPEN_BRUSH_APP_ID: 1634870
-          OPEN_BRUSH_WINDOWS_DEPOT_ID: 1634871
-          OPEN_BRUSH_EXECUTABLE: ${{ needs.configuration.outputs.basename}}.exe
-          CHANNEL: prerelease
-      # Upload the regular build to the experimental channels as well.
-      # TODO: remove at 2.0
-      - name: Upload Regular Build as experimental
-        run: |
-          pip install -U j2cli
-          j2 Support/steam/app.vdf.j2 > build_windows_openxr/app.vdf
-          j2 Support/steam/main_depot.vdf.j2 > build_windows_openxr/main_depot.vdf
-          j2 Support/steam/installscript_win.vdf.j2 > build_windows_openxr/installscript_win.vdf
-          steamcmd +login $STEAM_USERNAME $STEAM_PASSWORD +run_app_build $(pwd)/build_windows_openxr/app.vdf +quit
-        env:
-          STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
-          STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }}
-          VERSION: ${{ needs.configuration.outputs.version }}
-          OPEN_BRUSH_APP_ID: 1634870
-          OPEN_BRUSH_WINDOWS_DEPOT_ID: 1634871
-          OPEN_BRUSH_EXECUTABLE: ${{ needs.configuration.outputs.basename}}.exe
-          CHANNEL: beta-experimental
-      - name: Upload Legacy Build as experimental
-        run: |
-          pip install -U j2cli
-          j2 Support/steam/app.vdf.j2 > build_windows_openxr/app.vdf
-          j2 Support/steam/main_depot.vdf.j2 > build_windows_openxr/main_depot.vdf
-          j2 Support/steam/installscript_win.vdf.j2 > build_windows_openxr/installscript_win.vdf
-          steamcmd +login $STEAM_USERNAME $STEAM_PASSWORD +run_app_build $(pwd)/build_windows_openxr/app.vdf +quit
-        env:
-          STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
-          STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }}
-          VERSION: ${{ needs.configuration.outputs.version }}
-          OPEN_BRUSH_APP_ID: 1634870
-          OPEN_BRUSH_WINDOWS_DEPOT_ID: 1634871
-          OPEN_BRUSH_EXECUTABLE: ${{ needs.configuration.outputs.basename}}.exe
-          CHANNEL: prerelease-experimental
-
       - name: Save logs
         uses: actions/upload-artifact@v3
         if: ${{ failure() }}


### PR DESCRIPTION
After the merge of v2.0, stop uploading explicit experimental builds to Steam, since they're included after PR #344 (see also #346 ). 

We'll delete the prerelease-experimental and beta-experimental, and users will switch automatically to the main release channel.

Similarly, following #291 (and #315), we'll be deleting the prerelease channel; users who want the tip builds should switch to the beta channel.

This all needs to go into the release announcement