### PR TITLE
Don't show "uncategorized" in the release notes if it's empty

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -386,7 +386,6 @@ jobs:
           toTag: "${{ needs.configuration.outputs.currentrelease }}"
           configurationJson: |
             {
-              "template": "#{{CHANGELOG}}\n\n## 💬 Uncategorized\n\n#{{UNCATEGORIZED}}\n",
               "categories": [
                 {
                     "title": "## 🚀 Features",
@@ -397,12 +396,16 @@ jobs:
                     "labels": ["fix", "bugfix"]
                 },
                 {
-                    "title": "## Maintenance",
+                    "title": "## 🛠️ Maintenance",
                     "labels": ["maintenance"]
                 },
                 {
                     "title": "## 📦 Dependencies",
                     "labels": ["dependencies"]
+                },
+                {
+                    "title": "## 💬 Uncategorized",
+                    "labels": []
                 }
               ]
             }


### PR DESCRIPTION
Fixes #383 
Followup to #380 