### PR TITLE
Disable the automatic push of builds to Pimax and Viveport for non-formal builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -533,7 +533,7 @@ jobs:
     if: |
       github.event_name == 'push' &&
       github.repository == 'icosa-gallery/open-brush' &&
-      (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/v'))
+      contains(github.ref, 'refs/tags/v')
 
     steps:
       - name: Download Build Artifacts (Windows Pimax)
@@ -565,7 +565,7 @@ jobs:
     if: |
       github.event_name == 'push' &&
       github.repository == 'icosa-gallery/open-brush' &&
-      (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/v'))
+      contains(github.ref, 'refs/tags/v')
 
     steps:
       - name: Download Build Artifacts (Windows OpenXR)


### PR DESCRIPTION
Followup to #381 and #377; platforms that don't support release channels should only get formal builds.