### PR TITLE
Improve cache management in build system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,50 +135,7 @@ jobs:
           - name: Windows OpenXR
             targetPlatform: StandaloneWindows64
             vrsdk: OpenXR
-            cache: Windows
-
-          - name: Windows Pimax
-            targetPlatform: StandaloneWindows64
-            vrsdk: OpenXR
-            cache: Windows
-
-          - name: Windows Rift
-            targetPlatform: StandaloneWindows64
-            vrsdk: Oculus
-            cache: Windows
-
-          - name: Windows Monoscopic
-            targetPlatform: StandaloneWindows64
-            vrsdk: Monoscopic
-            cache: Windows
-
-          - name: Linux Monoscopic
-            targetPlatform: StandaloneLinux64
-            vrsdk: Monoscopic
-            cache: Linux
-
-          - name: MacOS Monoscopic
-            targetPlatform: StandaloneOSX
-            vrsdk: Monoscopic
-            cache: MacOS
-
-          - name: Android OpenXR
-            targetPlatform: Android
-            vrsdk: OpenXR
-            cache: Android_Vulkan
-            extraoptions: -btb-il2cpp
-
-          - name: Oculus Quest
-            targetPlatform: Android
-            vrsdk: Oculus
-            cache: Android_Vulkan
-            extraoptions: -btb-il2cpp
-
-          - name: Android Pico
-            targetPlatform: Android
-            vrsdk: Pico
-            cache: Android_GLES
-            extraoptions: -btb-il2cpp
+            cache: Windows2
 
     steps:
       - name: Free extra space

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,6 +265,8 @@ jobs:
           rm -rf tmp.plugin tmp.package
 
       - uses: actions/cache@v3
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 10
         with:
           path: Library
           # Some platforms share a cache; it's not a 1:1 mapping of either targetPlatform or vrsdk, so we have a distinct variable for which cache to use

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,50 @@ jobs:
           - name: Windows OpenXR
             targetPlatform: StandaloneWindows64
             vrsdk: OpenXR
-            cache: Windows2
+            cache: Windows
+
+          - name: Windows Pimax
+            targetPlatform: StandaloneWindows64
+            vrsdk: OpenXR
+            cache: Windows
+
+          - name: Windows Rift
+            targetPlatform: StandaloneWindows64
+            vrsdk: Oculus
+            cache: Windows
+
+          - name: Windows Monoscopic
+            targetPlatform: StandaloneWindows64
+            vrsdk: Monoscopic
+            cache: Windows
+
+          - name: Linux Monoscopic
+            targetPlatform: StandaloneLinux64
+            vrsdk: Monoscopic
+            cache: Linux
+
+          - name: MacOS Monoscopic
+            targetPlatform: StandaloneOSX
+            vrsdk: Monoscopic
+            cache: MacOS
+
+          - name: Android OpenXR
+            targetPlatform: Android
+            vrsdk: OpenXR
+            cache: Android_Vulkan
+            extraoptions: -btb-il2cpp
+
+          - name: Oculus Quest
+            targetPlatform: Android
+            vrsdk: Oculus
+            cache: Android_Vulkan
+            extraoptions: -btb-il2cpp
+
+          - name: Android Pico
+            targetPlatform: Android
+            vrsdk: Pico
+            cache: Android_GLES
+            extraoptions: -btb-il2cpp
 
     steps:
       - name: Free extra space

--- a/.github/workflows/delete_branch_cache.yml
+++ b/.github/workflows/delete_branch_cache.yml
@@ -1,0 +1,38 @@
+# yamllint disable rule:line-length
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+---
+# Taken from https://github.com/actions/cache/blob/main/tips-and-workarounds.md#force-deletion-of-caches-overriding-default-cache-eviction-policy
+name: cleanup caches by a branch
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - closed
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+          BRANCH=${{ github.ref }}
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We had some wonky cache issues recently, and builds that should have taken 25 minutes took over 2 hours. The root cause is that fetching the cache failed (after an hour!), and so it started compilation without a Library/ directory. But because it counted as a cache miss, it saved the cache on the branch, and because of the size, this caused it to later evict the cache on main.

This PR makes two changes:

1. Cache fetches will be aborted after 10 minutes. I've never seen it take more than 5 minutes and not time out in the end. Normal fetch should be less than 2 minutes.
2. If a feature branch cache is created, delete it immediately when the branch is done. There's never a reason to keep it around; no other branch, including main, can use it. (caches from main are used by branches)