### PR TITLE
Temporarily disable snap grab icon

### DIFF
--- a/Assets/Scripts/Widgets/GrabWidget.cs
+++ b/Assets/Scripts/Widgets/GrabWidget.cs
@@ -1565,8 +1565,11 @@ namespace TiltBrush
 
             // If the widget is pinned, don't pretend like we can snap it to things.
             bool show = m_AllowSnapping && !Pinned;
-            InputManager.GetControllerGeometry(m_InteractingController)
-                .TogglePadSnapHint(SnapEnabled, show);
+            // TODO:Mike 'SnapEnabled' is controlled by the new snap panel, rather than button input.
+            // This breaks using this button to quickly toggle on a grabbed object.
+            // Disabling icon for now to avoid confusion.
+            // InputManager.GetControllerGeometry(m_InteractingController)
+            //     .TogglePadSnapHint(SnapEnabled, show);
         }
 
         // Returns distance from center of collider if point is inside, 0..1


### PR DESCRIPTION
In #200 the snapping panel was introduced, which gives much finer control over snapping angles.
This results in the quick snap button on the controller no longer functioning, however it's visuals still appeared on the controller model.
This is a quick fix to prevent users getting confused.
(The tutorial regarding this interaction will be removed in #419)