### PR TITLE
Reset eye texture scale to 1

### DIFF
--- a/Assets/QualityLevels Mobile.asset
+++ b/Assets/QualityLevels Mobile.asset
@@ -21,7 +21,7 @@ MonoBehaviour:
     m_Anisotropic: 0
     m_BloomLevels: 2,3,3
     m_ViewportScale: 1
-    m_EyeTextureScale: 0.9
+    m_EyeTextureScale: 1
     m_StrokeSimplification: 0
     m_TargetMaxControlPoints: 50000
     m_MaxSimplification: 50
@@ -36,7 +36,7 @@ MonoBehaviour:
     m_Anisotropic: 0
     m_BloomLevels: 2,3,3
     m_ViewportScale: 1
-    m_EyeTextureScale: 0.9
+    m_EyeTextureScale: 1
     m_StrokeSimplification: 0
     m_TargetMaxControlPoints: 50000
     m_MaxSimplification: 50
@@ -51,7 +51,7 @@ MonoBehaviour:
     m_Anisotropic: 0
     m_BloomLevels: 2,3,3
     m_ViewportScale: 1
-    m_EyeTextureScale: 0.9
+    m_EyeTextureScale: 1
     m_StrokeSimplification: 0
     m_TargetMaxControlPoints: 50000
     m_MaxSimplification: 50
@@ -66,7 +66,7 @@ MonoBehaviour:
     m_Anisotropic: 0
     m_BloomLevels: 2,3,3
     m_ViewportScale: 1
-    m_EyeTextureScale: 0.9
+    m_EyeTextureScale: 1
     m_StrokeSimplification: 0
     m_TargetMaxControlPoints: 50000
     m_MaxSimplification: 50
@@ -81,7 +81,7 @@ MonoBehaviour:
     m_Anisotropic: 0
     m_BloomLevels: 2,3,3
     m_ViewportScale: 1
-    m_EyeTextureScale: 0.9
+    m_EyeTextureScale: 1
     m_StrokeSimplification: 0
     m_TargetMaxControlPoints: 50000
     m_MaxSimplification: 50
@@ -96,7 +96,7 @@ MonoBehaviour:
     m_Anisotropic: 0
     m_BloomLevels: 2,3,3
     m_ViewportScale: 1
-    m_EyeTextureScale: 0.9
+    m_EyeTextureScale: 1
     m_StrokeSimplification: 0
     m_TargetMaxControlPoints: 50000
     m_MaxSimplification: 50
@@ -111,7 +111,7 @@ MonoBehaviour:
     m_Anisotropic: 0
     m_BloomLevels: 2,3,3
     m_ViewportScale: 1
-    m_EyeTextureScale: 0.9
+    m_EyeTextureScale: 1
     m_StrokeSimplification: 0
     m_TargetMaxControlPoints: 50000
     m_MaxSimplification: 50


### PR DESCRIPTION
Was previously at 0.9 on all quality levels, meaning we ran below native res on mobile platforms.