### PR TITLE
To avoid loading for very long time when using China mobile hotspot

### DIFF
--- a/Assets/Scripts/Sharing/HttpServer.cs
+++ b/Assets/Scripts/Sharing/HttpServer.cs
@@ -33,6 +33,7 @@ namespace TiltBrush
         public int HttpPort => m_httpListenerPort;
 
         private HttpListener m_HttpListener;
+        private HttpListenerTimeoutManager m_HttpListenerTimeoutManager;
         private Dictionary<string, Action<HttpListenerContext>> m_HttpRequestHandlers =
             new Dictionary<string, Action<HttpListenerContext>>();
 
@@ -41,6 +42,8 @@ namespace TiltBrush
             try
             {
                 m_HttpListener = new HttpListener();
+                m_HttpListenerTimeoutManager.IdleConnection = TimeSpan.FromSeconds(5);
+                m_HttpListenerTimeoutManager.HeaderWait = TimeSpan.FromSeconds(5);
                 m_HttpListener.Prefixes.Add(String.Format("http://+:{0}/", m_httpListenerPort));
                 m_HttpListener.Start();
                 ThreadPool.QueueUserWorkItem((o) =>


### PR DESCRIPTION
China user reports Open Brush will load for very long time(~ 1 & 1/2 minute) to enter scene on VIVE device.
Test between connected to wifi and hotspot, this issue only happens when using hotspot.

NOTE: This issue also will occur on Oculus device, not sure if this solution should add to main branch.
 