### PR TITLE
Add a timeout to HttpListener to avoid loading for very long time when using China mobile hotspot

### DIFF
--- a/Assets/Scripts/Sharing/HttpServer.cs
+++ b/Assets/Scripts/Sharing/HttpServer.cs
@@ -33,6 +33,7 @@ namespace TiltBrush
         public int HttpPort => m_httpListenerPort;
 
         private HttpListener m_HttpListener;
+        private HttpListenerTimeoutManager m_HttpListenerTimeoutManager;
         private Dictionary<string, Action<HttpListenerContext>> m_HttpRequestHandlers =
             new Dictionary<string, Action<HttpListenerContext>>();
 
@@ -41,6 +42,9 @@ namespace TiltBrush
             try
             {
                 m_HttpListener = new HttpListener();
+                m_HttpListenerTimeoutManager = m_HttpListener.TimeoutManager;
+                m_HttpListenerTimeoutManager.IdleConnection = TimeSpan.FromSeconds(5);
+                m_HttpListenerTimeoutManager.HeaderWait = TimeSpan.FromSeconds(5);
                 m_HttpListener.Prefixes.Add(String.Format("http://+:{0}/", m_httpListenerPort));
                 m_HttpListener.Start();
                 ThreadPool.QueueUserWorkItem((o) =>


### PR DESCRIPTION
From the log, Open Brush stucked after HttpListener.Start() for 1 min 20 sec for unknown reason.