### PR TITLE
Revert "Add a HttpListener timeout"

### DIFF
--- a/Assets/Scripts/Sharing/HttpServer.cs
+++ b/Assets/Scripts/Sharing/HttpServer.cs
@@ -33,7 +33,6 @@ namespace TiltBrush
         public int HttpPort => m_httpListenerPort;
 
         private HttpListener m_HttpListener;
-        private HttpListenerTimeoutManager m_HttpListenerTimeoutManager;
         private Dictionary<string, Action<HttpListenerContext>> m_HttpRequestHandlers =
             new Dictionary<string, Action<HttpListenerContext>>();
 
@@ -42,9 +41,6 @@ namespace TiltBrush
             try
             {
                 m_HttpListener = new HttpListener();
-                m_HttpListenerTimeoutManager = m_HttpListener.TimeoutManager;
-                m_HttpListenerTimeoutManager.IdleConnection = TimeSpan.FromSeconds(5);
-                m_HttpListenerTimeoutManager.HeaderWait = TimeSpan.FromSeconds(5);
                 m_HttpListener.Prefixes.Add(String.Format("http://+:{0}/", m_httpListenerPort));
                 m_HttpListener.Start();
                 ThreadPool.QueueUserWorkItem((o) =>


### PR DESCRIPTION
This reverts commit 27234f1fb0d896b4aa42dd234874d95eb301b987.

I get an error:

```
NotImplementedException: The method or operation is not implemented.
System.Net.HttpListener.get_TimeoutManager () (at <cb1c94a571d140989f59bc38dfed683a>:0)
TiltBrush.HttpServer.Awake () (at Assets/Scripts/Sharing/HttpServer.cs:45)
```

And a quick search gives: https://issuetracker.unity3d.com/issues/notimplementedexception-when-calling-httplistener-dot-timeoutmanager

I suspect this _appeared_ to work for the original problem reported in #432 because it was throwing an exception and preventing the rest of the code in HttpServer.Awake from running.