### PR TITLE
Load HttpListener in a background thread; fixes delay on China mobile hotspots

### DIFF
--- a/Assets/Scripts/Sharing/HttpServer.cs
+++ b/Assets/Scripts/Sharing/HttpServer.cs
@@ -20,6 +20,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using UnityEngine;
 
 
@@ -37,6 +38,11 @@ namespace TiltBrush
             new Dictionary<string, Action<HttpListenerContext>>();
 
         void Awake()
+        {
+            Task.Run(() => { InitListener(); });
+        }
+
+        void InitListener()
         {
             try
             {


### PR DESCRIPTION
Fix loading for very long time when using China mobile hotspot, move HttpListener to background thread.