### PR TITLE
Add preserve legacy storage

### DIFF
--- a/Assets/Plugins/Android/AndroidManifest.xml
+++ b/Assets/Plugins/Android/AndroidManifest.xml
@@ -5,7 +5,8 @@
     <application
         android:allowBackup="false"
         tools:replace="android:allowBackup"
-        android:requestLegacyExternalStorage="true">
+        android:requestLegacyExternalStorage="true"
+        android:preserveLegacyExternalStorage="true">
         <activity
             android:launchMode="singleTask"
             android:name="com.unity3d.player.UnityPlayerActivity">


### PR DESCRIPTION
Prep for upgrade to new Android versions, should allow us to move data when ready.

https://developer.android.com/reference/android/R.attr#preserveLegacyExternalStorage

https://developer.oculus.com/blog/meta-quest-apps-android-12l-june-30/?locale=en_GB