### PR TITLE
Correctly calculate changelogs commensurate on commencement of correctional commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,9 +105,9 @@ jobs:
           then
             PREV=$(git describe --tags --abbrev=0 HEAD^)
           else
-            PREV=$(git describe --tags --match "v[0-9]*.[0-9]*" --abbrev=0 HEAD^)
+            PREV=$(git describe --tags --match "v[0-9]*.[0-9]*" --first-parent --abbrev=0 HEAD^)
           fi
-          PREVFULL=$(git describe --tags --match "v[0-9]*.[0-9]*" --abbrev=0 HEAD^)
+          PREVFULL=$(git describe --tags --match "v[0-9]*.[0-9]*" --first-parent --abbrev=0 HEAD^)
           CUR="$(git rev-parse HEAD)"
           echo "previousrelease=$PREV" >> $GITHUB_OUTPUT
           echo "previousfullrelease=$PREVFULL" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Correctly calculate changelogs when a hotfix has been released

When a hotfix was created, it means that the last vX.Y tag was not a --first-parent of the current tip. Since the hotfix (probably) just had cherry-picks, we want to include those PRs (as well as those that were not cherry-picked when releasing the next, formal, version. To do this, we need to go back to the last vX.Y tag that was made on a commit on main.

This only applies to the tag used to determine the change log. The version numbering for prerelease builds will still be based on the latest vX.Y tag, regardless of where it is.
