### PR TITLE
Keyboard code improvements and bug fixes

### DIFF
--- a/Assets/Prefabs/PopUps/PopUpWindow_SketchbookMenu.prefab
+++ b/Assets/Prefabs/PopUps/PopUpWindow_SketchbookMenu.prefab
@@ -931,7 +931,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8366139741319417911}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6c6859eec74651247968d56b594ac313, type: 3}
+  m_Script: {fileID: 11500000, guid: 68ab65faed9850448927b196242878d7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_DescriptionType: 0
@@ -997,6 +997,21 @@ MonoBehaviour:
   m_ToggleOnTexture: {fileID: 0}
   m_AllowUnavailable: 0
   m_LinkedUIObject: {fileID: 0}
+  m_BeforePopupAction:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 114000011997523446}
+        m_TargetAssemblyTypeName: TiltBrush.MenuPopUpWindow, Assembly-CSharp
+        m_MethodName: SetInitialKeyboardText
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   references:
     version: 2
     RefIds: []

--- a/Assets/Scripts/GUI/KeyboardPopUpWindow.cs
+++ b/Assets/Scripts/GUI/KeyboardPopUpWindow.cs
@@ -14,12 +14,14 @@
 
 using System;
 using System.IO;
+using UnityEngine;
 
 namespace TiltBrush
 {
     public class KeyboardPopUpWindow : OptionsPopUpWindow
     {
         private KeyboardUI m_KeyboardUI;
+        [NonSerialized] public static string m_InitialText;
         [NonSerialized] public static string m_LastInput;
 
         public bool m_SanitizeFilename;
@@ -30,20 +32,10 @@ namespace TiltBrush
             m_KeyboardUI.KeyPressed += KeyPressed;
         }
 
-        override public void SetPopupCommandParameters(int commandParam, int commandParam2)
+        override public void Init(GameObject rParent, string sText)
         {
-            if (commandParam2 != (int)SketchSetType.User)
-            {
-                return;
-            }
-            var sketchSet = SketchCatalog.m_Instance.GetSet(SketchSetType.User) as FileSketchSet;
-            var sceneFileInfo = sketchSet.GetSketchSceneFileInfo(commandParam);
-            var currentName = Path.GetFileName(sceneFileInfo.FullPath);
-            if (currentName.EndsWith(SaveLoadScript.TILT_SUFFIX))
-            {
-                currentName = currentName.Substring(0, currentName.Length - SaveLoadScript.TILT_SUFFIX.Length);
-            }
-            m_KeyboardUI.AddConsoleContent(currentName);
+            base.Init(rParent, sText);
+            m_KeyboardUI.AddConsoleContent(m_InitialText);
         }
 
         private void OnDestroy()

--- a/Assets/Scripts/GUI/KeyboardPopUpWindow.cs
+++ b/Assets/Scripts/GUI/KeyboardPopUpWindow.cs
@@ -36,6 +36,7 @@ namespace TiltBrush
         {
             base.Init(rParent, sText);
             m_KeyboardUI.AddConsoleContent(m_InitialText);
+            m_LastInput = m_InitialText;
         }
 
         private void OnDestroy()
@@ -48,6 +49,7 @@ namespace TiltBrush
             switch (e.Key.KeyType)
             {
                 case KeyboardKeyType.Enter:
+                    // Logic will been to be updated if we ever have a multi-line keyboard
                     m_LastInput = m_KeyboardUI.ConsoleContent;
                     if (m_ParentPanel)
                     {

--- a/Assets/Scripts/GUI/KeyboardPopupButton.cs
+++ b/Assets/Scripts/GUI/KeyboardPopupButton.cs
@@ -1,0 +1,32 @@
+// Copyright 2023 The Tilt Brush Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace TiltBrush
+{
+
+    public class KeyboardPopupButton : OptionButton
+    {
+        [SerializeField]
+        private UnityEvent<KeyboardPopupButton> m_BeforePopupAction;
+
+        override protected void OnButtonPressed()
+        {
+            m_BeforePopupAction.Invoke(this);
+            base.OnButtonPressed();
+        }
+    }
+} // namespace TiltBrush

--- a/Assets/Scripts/GUI/KeyboardPopupButton.cs.meta
+++ b/Assets/Scripts/GUI/KeyboardPopupButton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68ab65faed9850448927b196242878d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GUI/MenuPopUpWindow.cs
+++ b/Assets/Scripts/GUI/MenuPopUpWindow.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.IO;
+using UnityEngine;
 namespace TiltBrush
 {
 
@@ -25,6 +27,27 @@ namespace TiltBrush
             {
                 button.SetCommandParameters(iCommandParam, iCommandParam2);
             }
+
+            // The rename button should only be enabled for categories that support renaming
+            var renameButton = GetComponentInChildren<KeyboardPopupButton>();
+            SketchSetType sketchSetType = (SketchSetType)iCommandParam2;
+            renameButton.SetButtonAvailable(sketchSetType == SketchSetType.User);
+        }
+
+        // This code is specific to the "Rename" button in the Sketchbook menu
+        // This popup class is currently only used for the Sketchbook menu
+        // If that changes then this probably belongs in a subclass
+        public void SetInitialKeyboardText(KeyboardPopupButton btn)
+        {
+            SketchSetType sketchSetType = (SketchSetType)btn.m_CommandParam2;
+            var sketchSet = SketchCatalog.m_Instance.GetSet(SketchSetType.User) as FileSketchSet;
+            var sceneFileInfo = sketchSet.GetSketchSceneFileInfo(btn.m_CommandParam);
+            var currentName = Path.GetFileName(sceneFileInfo.FullPath);
+            if (currentName.EndsWith(SaveLoadScript.TILT_SUFFIX))
+            {
+                currentName = currentName.Substring(0, currentName.Length - SaveLoadScript.TILT_SUFFIX.Length);
+            }
+            KeyboardPopUpWindow.m_InitialText = currentName;
         }
     }
 

--- a/Assets/Scripts/GUI/OptionButton.cs
+++ b/Assets/Scripts/GUI/OptionButton.cs
@@ -22,7 +22,7 @@ namespace TiltBrush
     {
         [SerializeField] public SketchControlsScript.GlobalCommands m_Command;
         [SerializeField] public int m_CommandParam = -1;
-        [SerializeField] protected int m_CommandParam2 = -1;
+        [SerializeField] public int m_CommandParam2 = -1;
         [SerializeField] protected bool m_RequiresPopup = false;
         [SerializeField] protected bool m_CenterPopupOnButton = false;
         [SerializeField] protected Vector3 m_PopupOffset;

--- a/Assets/Scripts/Save/DiskSceneFileInfo.cs
+++ b/Assets/Scripts/Save/DiskSceneFileInfo.cs
@@ -235,12 +235,10 @@ namespace TiltBrush
             }
         }
 
-        public void Rename(string newName)
+        public string Rename(string newName)
         {
-            if (!Valid) { return; }
-
-            //look to delete the file version first
-            if (File.Exists(m_fullpath))
+            // Look to delete the file version first
+            if (Valid && File.Exists(m_fullpath))
             {
                 string dirPath = Path.GetDirectoryName(m_fullpath);
                 string newPath = Path.Combine(dirPath, $"{newName}{SaveLoadScript.TILT_SUFFIX}");
@@ -261,7 +259,10 @@ namespace TiltBrush
                 {
                     Debug.LogFormat("IO Exception: Can't Rename {0}", m_fullpath);
                 }
+
+                return newPath;
             }
+            return m_fullpath;
         }
 
         /// Returns a readable stream to a pre-existing subfile,

--- a/Assets/Scripts/Save/FileSketchSet.cs
+++ b/Assets/Scripts/Save/FileSketchSet.cs
@@ -354,7 +354,10 @@ namespace TiltBrush
                 driveSet.NotifySketchChanged(m_Sketches[toRename].SceneFileInfo.FullPath);
             }
 
-            m_Sketches[toRename].SceneFileInfo.Rename(newName);
+            var newPath = m_Sketches[toRename].SceneFileInfo.Rename(newName);
+
+            m_FileWatcher.NotifyCreated(newPath);
+
         }
 
         public virtual void Init()

--- a/Assets/Scripts/Save/SceneFileInfo.cs
+++ b/Assets/Scripts/Save/SceneFileInfo.cs
@@ -60,7 +60,7 @@ namespace TiltBrush
 
         void Delete();
 
-        void Rename(string newName);
+        string Rename(string newName);
 
         bool IsHeaderValid();
 

--- a/Assets/Scripts/Sharing/GoogleDriveSketchSet.cs
+++ b/Assets/Scripts/Sharing/GoogleDriveSketchSet.cs
@@ -114,7 +114,7 @@ namespace TiltBrush
                 throw new NotImplementedException();
             }
 
-            public void Rename(string newName)
+            public string Rename(string newName)
             {
                 throw new NotImplementedException();
             }

--- a/Assets/Scripts/Sharing/PolySketchSet.cs
+++ b/Assets/Scripts/Sharing/PolySketchSet.cs
@@ -841,7 +841,7 @@ namespace TiltBrush
             throw new NotImplementedException();
         }
 
-        public void Rename(string newName)
+        public string Rename(string newName)
         {
             throw new NotImplementedException();
         }

--- a/Assets/Scripts/SketchControlsScript.cs
+++ b/Assets/Scripts/SketchControlsScript.cs
@@ -4523,7 +4523,10 @@ namespace TiltBrush
                     {
                         var sketchSetType = (SketchSetType)iParam2;
                         SketchSet sketchSet = SketchCatalog.m_Instance.GetSet(sketchSetType);
-                        sketchSet.RenameSketch(iParam1, KeyboardPopUpWindow.m_LastInput);
+                        if (sketchSetType == SketchSetType.User)
+                        {
+                            sketchSet.RenameSketch(iParam1, KeyboardPopUpWindow.m_LastInput);
+                        }
                         DismissPopupOnCurrentGazeObject(false);
                         break;
                     }


### PR DESCRIPTION
1. KeyboardPopUpWindow shouldn't have code specific to renaming as it's meant to be generic for all uses of the keyboard.
2. Pretty sure this worked when I originally tested but the sketchbook didn't seem to be adding the renamed sketch back in. This fixes that also.