### PR TITLE
Add Quest support to the pure Android XR build

### DIFF
--- a/Assets/Plugins/Android/AndroidManifest.xml
+++ b/Assets/Plugins/Android/AndroidManifest.xml
@@ -12,6 +12,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="com.oculus.intent.category.VR"/>
             </intent-filter>
         </activity>
         <meta-data android:name="unityplayer.SkipPermissionsDialog" android:value="false" />


### PR DESCRIPTION
This PR alters the base manifest to include Quest's intent on the main activity, allowing our pure Android OpenXR builds to run on Quest with the default cross-platform loader.

Note: we aren't switching to full pure OpenXR on Quest yet due to issues with our shaders and rendering pipeline for passthrough when *not* using the oculus SDK implementation. This may be related to #420.