### PR TITLE
Update steam deployment to remove superflous parameters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -597,7 +597,6 @@ jobs:
         run: |
           mkdir -p /home/runner/Steam/config
           echo "${{ secrets.STEAM_CONFIG_VDF}}" | base64 -d - > /home/runner/Steam/config/config.vdf
-          echo "${{ secrets.STEAM_SSFN }}" | base64 -d - > /home/runner/Steam/${{ secrets.STEAM_SSFN_FILENAME }}
       - name: Download Build Artifacts (Windows OpenXR)
         uses: actions/download-artifact@v3
         with:
@@ -609,10 +608,9 @@ jobs:
           j2 Support/steam/app.vdf.j2 > build_windows_openxr/app.vdf
           j2 Support/steam/main_depot.vdf.j2 > build_windows_openxr/main_depot.vdf
           j2 Support/steam/installscript_win.vdf.j2 > build_windows_openxr/installscript_win.vdf
-          steamcmd +login $STEAM_USERNAME $STEAM_PASSWORD +run_app_build $(pwd)/build_windows_openxr/app.vdf +quit
+          steamcmd +login $STEAM_USERNAME +run_app_build $(pwd)/build_windows_openxr/app.vdf +quit
         env:
           STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
-          STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }}
           VERSION: ${{ needs.configuration.outputs.version }}
           OPEN_BRUSH_APP_ID: 1634870
           OPEN_BRUSH_WINDOWS_DEPOT_ID: 1634871


### PR DESCRIPTION
Same change as the steam-deploy action from
https://github.com/game-ci/steam-deploy/pull/57

(we don't use that action directly because we need an InstallScript in our Windows VDF)