### PR TITLE
Hotfix/selection snapping bugs

### DIFF
--- a/Assets/Scripts/Tools/FreePaintTool.GridSnap.cs
+++ b/Assets/Scripts/Tools/FreePaintTool.GridSnap.cs
@@ -47,9 +47,9 @@ namespace TiltBrush
                 );
 
             roundedCanvasPos = new Vector3(
-                !SelectionManager.m_Instance.m_EnableSnapTranslationX ? roundedCanvasPos.x : localCanvasPos.x,
-                !SelectionManager.m_Instance.m_EnableSnapTranslationY ? roundedCanvasPos.y : localCanvasPos.y,
-                !SelectionManager.m_Instance.m_EnableSnapTranslationZ ? roundedCanvasPos.z : localCanvasPos.z
+                SelectionManager.m_Instance.m_EnableSnapTranslationX ? roundedCanvasPos.x : localCanvasPos.x,
+                SelectionManager.m_Instance.m_EnableSnapTranslationY ? roundedCanvasPos.y : localCanvasPos.y,
+                SelectionManager.m_Instance.m_EnableSnapTranslationZ ? roundedCanvasPos.z : localCanvasPos.z
             );
 
             Vector3 offset = new Vector3(
@@ -85,6 +85,7 @@ namespace TiltBrush
                     snappedPos = new Vector3(roundedCanvasPos.x, roundedCanvasPos.y, localCanvasPos.z);
                 }
             }
+
             return App.Scene.MainCanvas.transform.localToWorldMatrix.MultiplyPoint3x4(snappedPos);
         }
 

--- a/Assets/Shaders/ReferenceImage.shader
+++ b/Assets/Shaders/ReferenceImage.shader
@@ -24,6 +24,7 @@ Shader "Custom/ReferenceImage" {
         Tags{ "Queue" = "AlphaTest+20" "IgnoreProjector" = "True" "RenderType" = "TransparentCutout" }
         Pass {
             Lighting Off
+            Cull Off
 
             CGPROGRAM
             #pragma vertex vert


### PR DESCRIPTION
1. Reference images and videos used 1-sided shaders. That might have made sense in the past but that results in unexpected results when duplicating with multimirror so I think it's time to change that
2. Snapping was broken because we fixed a UI bug in one branch but didn't update the snapping logic