### PR TITLE
Fix selection bug after cloning to multimirrors

### DIFF
--- a/Assets/Scripts/Commands/MultimirrorDuplicateCommand.cs
+++ b/Assets/Scripts/Commands/MultimirrorDuplicateCommand.cs
@@ -139,10 +139,19 @@ namespace TiltBrush
             }
 
             // Select widgets.
-            if (m_DuplicatedWidgets != null && !m_StampMode)
+            if (m_DuplicatedWidgets != null)
             {
-                SelectionManager.m_Instance.SelectWidgets(m_DuplicatedWidgets);
-                SelectionManager.m_Instance.RegisterWidgetsInSelectionCanvas(m_DuplicatedWidgets);
+                if (m_StampMode)
+                {
+                    SelectionManager.m_Instance.SelectWidgets(m_DuplicatedWidgets);
+                    SelectionManager.m_Instance.RegisterWidgetsInSelectionCanvas(m_DuplicatedWidgets);
+                    SelectionManager.m_Instance.DeselectWidgets(m_DuplicatedWidgets);
+                }
+                else
+                {
+                    SelectionManager.m_Instance.SelectWidgets(m_DuplicatedWidgets);
+                    SelectionManager.m_Instance.RegisterWidgetsInSelectionCanvas(m_DuplicatedWidgets);
+                }
             }
 
             // Set selection widget transforms.


### PR DESCRIPTION
1. Turn on multimirror
2. Add a 3d model to the scene
3. With the selection tool select the model 
4. Clone it whilst still holding it ("stamp mode")

Previously the newly cloned models couldn't be selected unless you messed around (invert selection followed by deselect seemed to fix it).