### PR TITLE
Opt-in large mesh support

### DIFF
--- a/Assets/Scripts/Batching/Batch.cs
+++ b/Assets/Scripts/Batching/Batch.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace TiltBrush
 {
@@ -109,6 +110,10 @@ namespace TiltBrush
             m_Geometry = new GeometryPool();
 
             var rNewMesh = new Mesh();
+            if (App.UserConfig.Flags.LargeMeshSupport)
+            {
+                rNewMesh.indexFormat = IndexFormat.UInt32;
+            }
             rNewMesh.MarkDynamic();
 
             gameObject.layer = ParentPool.Owner.Canvas.gameObject.layer;

--- a/Assets/Scripts/Export/ExportCollector.cs
+++ b/Assets/Scripts/Export/ExportCollector.cs
@@ -268,7 +268,8 @@ namespace TiltBrush
             foreach (ExportUtils.ExportBrush brush in exportGroup.SplitByBrush())
             {
                 var desc = brush.m_desc;
-                foreach (var (batch, batchIndex) in brush.ToGeometryBatches().WithIndex())
+                int vertexLimit = App.UserConfig.Flags.LargeMeshSupport ? 2147483645 : 65534;
+                foreach (var (batch, batchIndex) in brush.ToGeometryBatches(vertexLimit).WithIndex())
                 {
                     GeometryPool geometry = batch.pool;
                     List<Stroke> strokes = batch.strokes;

--- a/Assets/Scripts/Export/ExportCollector.cs
+++ b/Assets/Scripts/Export/ExportCollector.cs
@@ -268,10 +268,10 @@ namespace TiltBrush
             foreach (ExportUtils.ExportBrush brush in exportGroup.SplitByBrush())
             {
                 var desc = brush.m_desc;
-                // Values are 2 ^ 16 - 1 or 2 ^ 31 - 1
-                // The actual upper limit is 2 ^ 32 -1 but we can't use uint as lots of code uses int
+                // Values are 2 ^ 16 - 2 or 2 ^ 31 - 2
+                // The actual upper limit is 2 ^ 32 - 2 but we can't use uint as lots of code uses int
                 // Also 2 billion verts is realistically more than enough for any practical purpose
-                int vertexLimit = App.UserConfig.Flags.LargeMeshSupport ? 2147483647 : 65534;
+                int vertexLimit = App.UserConfig.Flags.LargeMeshSupport ? 2147483646 : 65534;
                 foreach (var (batch, batchIndex) in brush.ToGeometryBatches(vertexLimit).WithIndex())
                 {
                     GeometryPool geometry = batch.pool;

--- a/Assets/Scripts/Export/ExportCollector.cs
+++ b/Assets/Scripts/Export/ExportCollector.cs
@@ -268,7 +268,10 @@ namespace TiltBrush
             foreach (ExportUtils.ExportBrush brush in exportGroup.SplitByBrush())
             {
                 var desc = brush.m_desc;
-                int vertexLimit = App.UserConfig.Flags.LargeMeshSupport ? 2147483645 : 65534;
+                // Values are 2 ^ 16 - 1 or 2 ^ 31 - 1
+                // The actual upper limit is 2 ^ 32 -1 but we can't use uint as lots of code uses int
+                // Also 2 billion verts is realistically more than enough for any practical purpose
+                int vertexLimit = App.UserConfig.Flags.LargeMeshSupport ? 2147483647 : 65534;
                 foreach (var (batch, batchIndex) in brush.ToGeometryBatches(vertexLimit).WithIndex())
                 {
                     GeometryPool geometry = batch.pool;

--- a/Assets/Scripts/UserConfig.cs
+++ b/Assets/Scripts/UserConfig.cs
@@ -41,6 +41,7 @@ namespace TiltBrush
             public bool GuideToggleVisiblityOnly;
             public bool HighResolutionSnapshots; // Deprecated
             public bool ShowDroppedFrames;
+            public bool LargeMeshSupport;
 
             public bool EnableApiRemoteCalls;
             public bool EnableApiCorsHeaders;


### PR DESCRIPTION
Previously tried and reverted here: https://github.com/icosa-gallery/open-brush/commit/3940924a4b02e547e21ed2bc731329661941c543 (#279 / #349)

This time:

1. It's a config file setting that defaults to off
2. I think I know the fix for SDK/Toolkit - will test and patch if I'm correct