### PR TITLE
Use total pixels instead of max(width, height) for determining the maximum image size

### DIFF
--- a/Assets/PlatformConfigMobile.asset
+++ b/Assets/PlatformConfigMobile.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   HullBrushMaxVertInputs: 400
   HullBrushMaxKnots: 900
   ReferenceImagesMaxFileSize: 10485760
-  ReferenceImagesMaxDimension: 4096
+  ReferenceImagesMaxDimension: 4352
   ReferenceImagesResizeDimension: 1024
   MemoryWarningVertCount: 1000000
   UseFileSystemWatcher: 0

--- a/Assets/Scripts/Util/ImageUtils.cs
+++ b/Assets/Scripts/Util/ImageUtils.cs
@@ -87,7 +87,8 @@ namespace TiltBrush
                 }
             }
 
-            if (imageWidth * imageHeight > maxDimension * maxDimension)
+            // Cast to long as maxDimension is big enough on desktop to overflow
+            if (imageWidth * imageHeight > ((long)maxDimension * (long)maxDimension))
             {
                 throw new ImageLoadError(
                     String.Format("Image dimensions {0}x{1} are greater than max dimensions of {2}x{2}!",

--- a/Assets/Scripts/Util/ImageUtils.cs
+++ b/Assets/Scripts/Util/ImageUtils.cs
@@ -87,7 +87,7 @@ namespace TiltBrush
                 }
             }
 
-            if (imageWidth > maxDimension || imageHeight > maxDimension)
+            if (imageWidth * imageHeight > maxDimension * maxDimension)
             {
                 throw new ImageLoadError(
                     String.Format("Image dimensions {0}x{1} are greater than max dimensions of {2}x{2}!",


### PR DESCRIPTION
Also increase the Quest limit slightly.

This fixes one of the example included panoramas not loading on the Quest. It's easier to do this than to override the logic to force a new example image to copy into the Media Library and it seems like a better approach in any case.