### PR TITLE
Add gamepad movement controls for non-VR mode

### DIFF
--- a/Assets/Scripts/Tools/FlyTool.cs
+++ b/Assets/Scripts/Tools/FlyTool.cs
@@ -117,12 +117,17 @@ namespace TiltBrush
             // Handle non-VR navigation
             if (!App.VrSdk.IsHmdInitialized())
             {
-
                 if (!EnhancedTouchSupport.enabled) EnhancedTouchSupport.Enable();
+
+                Gamepad gamepad = Gamepad.current;
                 Vector2 mv = Vector2.zero;
                 if (Mouse.current != null && Mouse.current.leftButton.isPressed)
                 {
-                    mv = InputManager.m_Instance.GetMouseMoveDelta();
+                    mv += InputManager.m_Instance.GetMouseMoveDelta();
+                }
+                if (gamepad != null)
+                {
+                    mv += gamepad.rightStick.ReadValue() * 3f;
                 }
 
                 var virtualButtons = new Dictionary<char, bool> { { 'W', false }, { 'A', false }, { 'S', false }, { 'D', false } };
@@ -170,34 +175,43 @@ namespace TiltBrush
 
                 Vector3 cameraTranslation = Vector3.zero;
 
-                bool isSprinting = InputManager.m_Instance.GetKeyboardShortcut(InputManager.KeyboardShortcut.SprintMode);
+                bool isSprinting = InputManager.m_Instance.GetKeyboardShortcut(InputManager.KeyboardShortcut.SprintMode) ||
+                                   (gamepad != null && gamepad.leftStickButton.isPressed);
                 float movementSpeed = isSprinting ? 0.3f : 0.05f;
+
+                if (gamepad != null)
+                {
+                    Vector2 move = gamepad.leftStick.ReadValue();
+                    cameraTranslation += new Vector3(move.x, 0f, move.y);
+                    float upDown = gamepad.rightTrigger.ReadValue() - gamepad.leftTrigger.ReadValue();
+                    cameraTranslation += Vector3.up * upDown;
+                }
 
                 if (InputManager.m_Instance.GetKeyboardShortcut(InputManager.KeyboardShortcut.CameraMoveForward) || virtualButtons['W'])
                 {
-                    cameraTranslation = Vector3.forward;
+                    cameraTranslation += Vector3.forward;
                 }
-                else if (InputManager.m_Instance.GetKeyboardShortcut(InputManager.KeyboardShortcut.CameraMoveBackwards) || virtualButtons['S'])
+                if (InputManager.m_Instance.GetKeyboardShortcut(InputManager.KeyboardShortcut.CameraMoveBackwards) || virtualButtons['S'])
                 {
-                    cameraTranslation = Vector3.back;
+                    cameraTranslation += Vector3.back;
                 }
-                else if (InputManager.m_Instance.GetKeyboardShortcut(InputManager.KeyboardShortcut.CameraMoveUp))
+                if (InputManager.m_Instance.GetKeyboardShortcut(InputManager.KeyboardShortcut.CameraMoveUp))
                 {
-                    cameraTranslation = Vector3.up;
+                    cameraTranslation += Vector3.up;
                 }
-                else if (InputManager.m_Instance.GetKeyboardShortcut(InputManager.KeyboardShortcut.CameraMoveDown))
+                if (InputManager.m_Instance.GetKeyboardShortcut(InputManager.KeyboardShortcut.CameraMoveDown))
                 {
-                    cameraTranslation = Vector3.down;
+                    cameraTranslation += Vector3.down;
                 }
-                else if (InputManager.m_Instance.GetKeyboardShortcut(InputManager.KeyboardShortcut.CameraMoveLeft) || virtualButtons['A'])
+                if (InputManager.m_Instance.GetKeyboardShortcut(InputManager.KeyboardShortcut.CameraMoveLeft) || virtualButtons['A'])
                 {
-                    cameraTranslation = Vector3.left;
+                    cameraTranslation += Vector3.left;
                 }
-                else if (InputManager.m_Instance.GetKeyboardShortcut(InputManager.KeyboardShortcut.CameraMoveRight) || virtualButtons['D'])
+                if (InputManager.m_Instance.GetKeyboardShortcut(InputManager.KeyboardShortcut.CameraMoveRight) || virtualButtons['D'])
                 {
-                    cameraTranslation = Vector3.right;
+                    cameraTranslation += Vector3.right;
                 }
-                else if (InputManager.m_Instance.GetKeyboardShortcutDown(InputManager.KeyboardShortcut.InvertLook))
+                if (InputManager.m_Instance.GetKeyboardShortcutDown(InputManager.KeyboardShortcut.InvertLook))
                 {
                     m_InvertLook = !m_InvertLook;
                 }

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Follow these steps when running the application for the first time:
     Essential Resources**.
 1.  Press **Play**.
 
+When no VR headset is detected, Open Brush can be navigated using the WASD keys or a connected gamepad.
+
 These steps have been tested with Release 1.0.54.
 
 ### Building the application from the Unity editor


### PR DESCRIPTION
## Summary
- allow camera movement with gamepad left stick and triggers in non-VR mode
- support camera rotation using gamepad right stick
- document gamepad navigation in README

## Testing
- `pre-commit run --files Assets/Scripts/Tools/FlyTool.cs README.md` *(fails: pre-commit not installed)*
- `pip install pre-commit` *(fails: Cannot connect to proxy / no matching distribution)*
- `dotnet format whitespace --include Assets/Scripts/Tools/FlyTool.cs` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a1ec467c83318fa03533596467eb