### PR TITLE
Update Zapbox SDK to 0.5.0

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -28,7 +28,7 @@
     "com.unity.xr.oculus": "4.2.0",
     "com.unity.xr.openxr": "1.10.0",
     "com.watertrans.glyphloader": "https://github.com/icosa-mirror/GlyphLoader-Unity.git#upm",
-    "com.zappar.xr.zapbox": "https://github.com/zappar-xr/zapbox-xr-sdk.git#74fe120c1c9a0b31a186eb551ef25efe4a316c73",
+    "com.zappar.xr.zapbox": "https://github.com/zappar-xr/zapbox-xr-sdk.git#91b52bde3c0a67aa08909bdd2657f8a6672decf6",
     "moonsharp": "https://github.com/icosa-mirror/moonsharp-unity-upm.git",
     "org.khronos.unitygltf": "https://github.com/KhronosGroup/UnityGLTF.git#dev",
     "org.nuget.google.apis": "1.64.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -356,14 +356,14 @@
       "hash": "6554bc1dce4f363437c6a9d42719f2756f24cf49"
     },
     "com.zappar.xr.zapbox": {
-      "version": "https://github.com/zappar-xr/zapbox-xr-sdk.git#74fe120c1c9a0b31a186eb551ef25efe4a316c73",
+      "version": "https://github.com/zappar-xr/zapbox-xr-sdk.git#91b52bde3c0a67aa08909bdd2657f8a6672decf6",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.unity.xr.management": "3.2.9",
         "com.unity.xr.legacyinputhelpers": "2.1.4"
       },
-      "hash": "74fe120c1c9a0b31a186eb551ef25efe4a316c73"
+      "hash": "91b52bde3c0a67aa08909bdd2657f8a6672decf6"
     },
     "moonsharp": {
       "version": "https://github.com/icosa-mirror/moonsharp-unity-upm.git",


### PR DESCRIPTION
Update the Zapbox SDK.

This improves async timewarp on iOS 26 (CADisplayLink got really janky in iOS 26, the newer CAMetalDisplayLink seems more dependable).

It should also improve multiplayer as the headset origin is now reported as the midpoint of the eyes as I think is generally expected by Unity. Previously it was the position of the camera on the device and the eyes were offset backwards, which meant in multiplayer you could see your own avatar a bit.