### PR TITLE
Fix loading selected strokes on Android

### DIFF
--- a/Assets/Scripts/Commands/LoadSavedStrokesCommand.cs
+++ b/Assets/Scripts/Commands/LoadSavedStrokesCommand.cs
@@ -107,7 +107,7 @@ namespace TiltBrush
                 // we need to set App.PlatformConfig.QuickLoadMaxDistancePerFrame to a very large value
                 // Without this strokes were not loaded correctly on Android devices where this value is low by default
                 float originalMaxDistance = App.PlatformConfig.QuickLoadMaxDistancePerFrame;
-                App.PlatformConfig.QuickLoadMaxDistancePerFrame = 10000.0f;
+                App.PlatformConfig.QuickLoadMaxDistancePerFrame = float.MaxValue;
                 SketchMemoryScript.m_Instance.BeginDrawingFromMemory(bDrawFromStart: true, false, false);
                 SketchMemoryScript.m_Instance.QuickLoadDrawingMemory();
                 SketchMemoryScript.m_Instance.ContinueDrawingFromMemory();


### PR DESCRIPTION
Ensure we fully load saved strokes in a single frame