### PR TITLE
Fix permanent black screen and brush panel not populating on startup

### DIFF
--- a/Assets/Scripts/API/GUI/ScriptsPanel.cs
+++ b/Assets/Scripts/API/GUI/ScriptsPanel.cs
@@ -24,11 +24,18 @@ namespace TiltBrush
         public BaseButton ToolScriptButton;
         public ToggleButton BackgroundScriptsButton;
 
+
+
+        // Added null-check for LuaManager.Instance to prevent black screen race condition
+        // during startup (panel creation could fail silently if LuaManager was not ready).
         protected override void OnEnablePanel()
         {
             base.OnEnablePanel();
-            // Safe to run multiple times as it checks m_IsInitialized
-            LuaManager.Instance?.Init();
+
+            if (LuaManager.Instance != null)
+            {
+                LuaManager.Instance.Init();
+            }
         }
 
         public void InitScriptUiNav()

--- a/Assets/Scripts/API/Lua/LuaManager.cs
+++ b/Assets/Scripts/API/Lua/LuaManager.cs
@@ -170,9 +170,17 @@ namespace TiltBrush
             m_ScriptPathsToUpdate.Add(e.FullPath);
         }
 
+        // Fixes MissingReferenceException causing black screen, prevents calling StartCoroutine on a destroyed or inactive LuaManager object.
         public void Init(bool immediate = false)
         {
             if (m_IsInitialized) return;
+
+            // SAFETY FIX - prevents crash when LuaManager is destroyed during startup
+            if (this == null || gameObject == null || !gameObject.activeInHierarchy)
+            {
+                return;
+            }
+
             if (immediate)
             {
                 _InitImpl();

--- a/Assets/Scripts/BrushCatalog.cs
+++ b/Assets/Scripts/BrushCatalog.cs
@@ -129,6 +129,9 @@ namespace TiltBrush
 
         /// Begins reloading any brush assets that come from loose files.
         /// The "BrushCatalogChanged" event will be fired when this is complete.
+
+        // FIX: Added missing m_IsLoading = false;
+        // This was causing permanent black screen on startup (app stayed stuck in LoadingBrushesAndLighting state).
         public void BeginReload()
         {
             m_IsLoading = true;
@@ -197,6 +200,7 @@ namespace TiltBrush
                     m_GuiBrushList.Add(brush);
                 }
             }
+            m_IsLoading = false;
             BrushCatalogChanged?.Invoke();
         }
 

--- a/Assets/Scripts/Brushes/BrushDescriptor.cs
+++ b/Assets/Scripts/Brushes/BrushDescriptor.cs
@@ -27,8 +27,16 @@ namespace TiltBrush
         const string EXPORT_TEXTURE_DIR = "Support/ExportTextures";
         const string EXPORT_TEXTURE_EXTENSION = ".png";
 
+        // BrushDescriptor.OnEnable
+        // Added null-check for m_BrushPrefab to stop UnassignedReferenceException crashing BrushLister.
         public void OnEnable()
         {
+            if (m_BrushPrefab == null)
+            {
+                Debug.LogWarning($"[BrushDescriptor] {name} has null m_BrushPrefab - skipping");
+                return;
+            }
+
             m_BrushScript = m_BrushPrefab.GetComponent<BaseBrushScript>();
             if (m_BrushScript == null)
             {


### PR DESCRIPTION
- BrushCatalog.BeginReload: Added m_IsLoading = false; at the end so loading completes and the brush panel populates
- BrushDescriptor.OnEnable: Added null-check for m_BrushPrefab to prevent BrushLister crash
- LuaManager.Init: Added safety check for destroyed/inactive object
- ScriptsPanel.OnEnablePanel: Added null-check for LuaManager.Instance to prevent race condition during panel creation