### PR TITLE
Resolve ModelWidget subtrees by unique node suffixes

### DIFF
--- a/Assets/Editor/Tests/TestTransformExtensions.cs
+++ b/Assets/Editor/Tests/TestTransformExtensions.cs
@@ -79,6 +79,50 @@ namespace TiltBrush
         }
 
         [Test]
+        public void TestFindSubtreeRootUsesUniqueSuffixes()
+        {
+            var root = new GameObject("ImportedObjRoot").transform;
+            var firstGroup = new GameObject("group[ob:0]").transform;
+            var secondGroup = new GameObject("group[ob:1]").transform;
+            firstGroup.parent = root;
+            secondGroup.parent = root;
+
+            try
+            {
+                var result = ModelWidget.FindSubtreeRoot(root, "/ImportedObjRoot[ob:0]/group[ob:1].mesh");
+
+                Assert.AreSame(secondGroup, result.node);
+                Assert.IsTrue(result.excludeChildren);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(root.gameObject);
+            }
+        }
+
+        [Test]
+        public void TestFindSubtreeRootUsesUniqueSuffixesForUnsuffixedDuplicateSiblings()
+        {
+            var root = new GameObject("Root").transform;
+            var firstWheel = new GameObject("Wheel").transform;
+            var secondWheel = new GameObject("Wheel").transform;
+            firstWheel.parent = root;
+            secondWheel.parent = root;
+
+            try
+            {
+                var result = ModelWidget.FindSubtreeRoot(root, "Root/Wheel[ob:1]");
+
+                Assert.AreSame(secondWheel, result.node);
+                Assert.IsFalse(result.excludeChildren);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(root.gameObject);
+            }
+        }
+
+        [Test]
         public void TestGlobalAccessor()
         {
             var AsGlobal = new TransformExtensions.GlobalAccessor();

--- a/Assets/Scripts/Widgets/ModelWidget.cs
+++ b/Assets/Scripts/Widgets/ModelWidget.cs
@@ -448,21 +448,128 @@ namespace TiltBrush
                 subpathToTraverse = subpathToTraverse.Substring(0, subpathToTraverse.Length - ".mesh".Length);
                 excludeChildren = true;
             }
-            if (node.name == subpathToTraverse)
+            string[] subtreePathSegments = GetSubtreePathSegments(subpathToTraverse);
+            if (subtreePathSegments.Length == 0)
             {
-                // We're already at the right node
-                // No need to do anything
-                Debug.LogWarning($"Didn't expect to get here...");
+                return (node, excludeChildren);
             }
-            else
+
+            if (TransformNameMatchesSegment(node.name, subtreePathSegments[0]))
             {
-                if (subpathToTraverse.StartsWith($"{node.name}/"))
-                {
-                    subpathToTraverse = subpathToTraverse.Substring(node.name.Length + 1);
-                }
-                node = string.IsNullOrEmpty(subpathToTraverse) ? node : node.Find(subpathToTraverse);
+                subtreePathSegments = subtreePathSegments.Skip(1).ToArray();
             }
+
+            node = FindSubtreeDescendant(node, subtreePathSegments);
             return (node, excludeChildren);
+        }
+
+        private static string[] GetSubtreePathSegments(string subtreePath)
+        {
+            return subtreePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        private static Transform FindSubtreeDescendant(Transform root, string[] pathSegments)
+        {
+            Transform node = root;
+            foreach (string segment in pathSegments)
+            {
+                node = FindSubtreeChild(node, segment);
+                if (node == null)
+                {
+                    return null;
+                }
+            }
+            return node;
+        }
+
+        private static Transform FindSubtreeChild(Transform parent, string segment)
+        {
+            foreach (Transform child in parent)
+            {
+                if (child.name == segment)
+                {
+                    return child;
+                }
+            }
+
+            if (!TryParseUniqueNodeSegment(segment, out string segmentName, out int segmentId))
+            {
+                return null;
+            }
+
+            int unsuffixedSiblingIndex = 0;
+            foreach (Transform child in parent)
+            {
+                // Imported glTF nodes may be saved as "Name[ob:n]". Treat that suffix as a
+                // sibling selector so duplicate node names can still resolve to a specific child.
+                if (TryParseUniqueNodeSegment(child.name, out string childName, out int childId))
+                {
+                    if (childName == segmentName && childId == segmentId)
+                    {
+                        return child;
+                    }
+                    continue;
+                }
+
+                if (child.name == segmentName)
+                {
+                    if (unsuffixedSiblingIndex == segmentId)
+                    {
+                        return child;
+                    }
+                    unsuffixedSiblingIndex++;
+                }
+            }
+            return null;
+        }
+
+        private static bool TransformNameMatchesSegment(string transformName, string segment)
+        {
+            if (transformName == segment)
+            {
+                return true;
+            }
+
+            if (!TryParseUniqueNodeSegment(segment, out string segmentName, out int segmentId))
+            {
+                return false;
+            }
+
+            if (TryParseUniqueNodeSegment(transformName, out string transformSegmentName, out int transformSegmentId))
+            {
+                return transformSegmentName == segmentName && transformSegmentId == segmentId;
+            }
+
+            return transformName == segmentName;
+        }
+
+        private static bool TryParseUniqueNodeSegment(string segment, out string name, out int uniqueId)
+        {
+            const string uniqueIdPrefix = "[ob:";
+            name = null;
+            uniqueId = -1;
+
+            if (!segment.EndsWith("]"))
+            {
+                return false;
+            }
+
+            int uniqueIdStart = segment.LastIndexOf(uniqueIdPrefix, StringComparison.Ordinal);
+            if (uniqueIdStart < 0)
+            {
+                return false;
+            }
+
+            string id = segment.Substring(
+                uniqueIdStart + uniqueIdPrefix.Length,
+                segment.Length - uniqueIdStart - uniqueIdPrefix.Length - 1);
+            if (!int.TryParse(id, out uniqueId))
+            {
+                return false;
+            }
+
+            name = segment.Substring(0, uniqueIdStart);
+            return true;
         }
 
         // Update the transform hierarchy of this ModelWidget to only contain m_Subtree


### PR DESCRIPTION
## Summary

- Replace the final `Transform.Find(path)` lookup in `ModelWidget.FindSubtreeRoot()` with segment-by-segment subtree resolution.
- Treat Open Brush `[ob:n]` node suffixes as sibling selectors so duplicated glTF node names can resolve to a specific child.
- Add editmode regression coverage for suffixed imported-node paths and unsuffixed duplicate sibling names.

## Validation

- `git diff --check HEAD~1 HEAD`
- Added Unity editmode tests in `Assets/Editor/Tests/TestTransformExtensions.cs`:
  - `TestFindSubtreeRootUsesUniqueSuffixes`
  - `TestFindSubtreeRootUsesUniqueSuffixesForUnsuffixedDuplicateSiblings`

I could not run the Unity editmode test locally in this checkout because the workstation only has Unity 6000.x installed, while this project asks for Unity 2022.3.34f1, and the local worktree is a sparse partial checkout containing only the changed source/test files. The PR is intentionally limited to C# source/tests so CI can validate it in the project environment.

Fixes #794

---

AI-assisted contribution disclosure: I used Codex to inspect the issue, implement the patch, and run the validation above. I reviewed the code diff before submitting.