### PR TITLE
Only show Meta XR prompt for Android build targets

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "com.coplaydev.unity-mcp": "https://github.com/CoplayDev/unity-mcp.git?path=/MCPForUnity#beta",
     "com.ixxy.unitysymmetry": "https://github.com/IxxyXR/unity-symmetry.git?nocache=7#upm",
-    "com.meta.xr.sdk.core": "https://github.com/icosa-mirror/com.meta.xr.sdk.core.git#68.0.2-openbrush-hotfix",
+    "com.meta.xr.sdk.core": "https://github.com/icosa-mirror/com.meta.xr.sdk.core.git#68.0.2-openbrush-hotfix.1",
     "com.meta.xr.sdk.platform": "60.0.0",
     "com.sandrofigo.voxreader": "5.0.6",
     "com.unity.2d.sprite": "1.0.0",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "com.coplaydev.unity-mcp": "https://github.com/CoplayDev/unity-mcp.git?path=/MCPForUnity#beta",
     "com.ixxy.unitysymmetry": "https://github.com/IxxyXR/unity-symmetry.git?nocache=7#upm",
-    "com.meta.xr.sdk.core": "https://github.com/icosa-mirror/com.meta.xr.sdk.core.git#68.0.2-openbrush-hotfix.1",
+    "com.meta.xr.sdk.core": "https://github.com/icosa-mirror/com.meta.xr.sdk.core.git#68.0.2-openbrush-hotfix.2",
     "com.meta.xr.sdk.platform": "60.0.0",
     "com.sandrofigo.voxreader": "5.0.6",
     "com.unity.2d.sprite": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -24,11 +24,11 @@
       "hash": "4f87195d54ccefe076678cb83a296b3f0428fc53"
     },
     "com.meta.xr.sdk.core": {
-      "version": "https://github.com/icosa-mirror/com.meta.xr.sdk.core.git#68.0.2-openbrush-hotfix.1",
+      "version": "https://github.com/icosa-mirror/com.meta.xr.sdk.core.git#68.0.2-openbrush-hotfix.2",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "6dc4f5904c9f8c24cfb0917ba9b3a285a6dfd1c2"
+      "hash": "76b391f8800a2adb40ef9d3854d870ae26c04a85"
     },
     "com.meta.xr.sdk.platform": {
       "version": "60.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -24,11 +24,11 @@
       "hash": "4f87195d54ccefe076678cb83a296b3f0428fc53"
     },
     "com.meta.xr.sdk.core": {
-      "version": "https://github.com/icosa-mirror/com.meta.xr.sdk.core.git#68.0.2-openbrush-hotfix",
+      "version": "https://github.com/icosa-mirror/com.meta.xr.sdk.core.git#68.0.2-openbrush-hotfix.1",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "cc9462850915e74dbb5cd6094f77464c5e606da1"
+      "hash": "6dc4f5904c9f8c24cfb0917ba9b3a285a6dfd1c2"
     },
     "com.meta.xr.sdk.platform": {
       "version": "60.0.0",


### PR DESCRIPTION
## What changed

Updates the Meta XR Core SDK fork to `68.0.2-openbrush-hotfix.2`.

The fork now returns from its feature-set initializer unless Android is the active Unity build target. Android projects retain the existing feature prompt and batch-mode behavior.

## Why

The previous hotfix stopped checking the Standalone feature set, but still checked Android unconditionally. That caused the Android Meta XR feature modal to appear while editing a PC/Desktop build.

## Validation

- Verified the project resolves the forked package and exact tagged commit.
- Parsed `Packages/manifest.json` and `Packages/packages-lock.json` successfully.
- Ran `git diff --check`.
- Full target builds run through this PR's GitHub Actions checks.